### PR TITLE
Improve error diagnostic messages for PF validation errors

### DIFF
--- a/internal/resource/config/authenticationapi/application/authentication_api_application_resource.go
+++ b/internal/resource/config/authenticationapi/application/authentication_api_application_resource.go
@@ -29,6 +29,7 @@ var (
 	_ resource.ResourceWithImportState = &authenticationApiApplicationResource{}
 
 	emptyStringSet, _ = types.SetValue(types.StringType, nil)
+	customId          = "application_id"
 )
 
 // AuthenticationApiApplicationResource is a helper function to simplify the provider implementation.
@@ -162,7 +163,7 @@ func (r *authenticationApiApplicationResource) Create(ctx context.Context, req r
 	apiCreateAuthenticationApiApplication = apiCreateAuthenticationApiApplication.Body(*createAuthenticationApiApplication)
 	authenticationApiApplicationResponse, httpResp, err := r.apiClient.AuthenticationApiAPI.CreateApplicationExecute(apiCreateAuthenticationApiApplication)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating an Authentication Api Application", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating an Authentication Api Application", err, httpResp, &customId)
 		return
 	}
 
@@ -172,7 +173,7 @@ func (r *authenticationApiApplicationResource) Create(ctx context.Context, req r
 	if internaltypes.IsDefined(plan.ClientForRedirectlessModeRef) {
 		authenticationApiApplicationResponse, httpResp, err = r.apiClient.AuthenticationApiAPI.GetApplication(config.AuthContext(ctx, r.providerConfig), plan.ApplicationId.ValueString()).Execute()
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp, &customId)
 		}
 	}
 
@@ -199,7 +200,7 @@ func (r *authenticationApiApplicationResource) Read(ctx context.Context, req res
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Authentication API Application", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp, &customId)
 		}
 		return
 	}
@@ -233,7 +234,7 @@ func (r *authenticationApiApplicationResource) Update(ctx context.Context, req r
 	updateAuthenticationApiApplication = updateAuthenticationApiApplication.Body(*createUpdateRequest)
 	updateAuthenticationApiApplicationResponse, httpResp, err := r.apiClient.AuthenticationApiAPI.UpdateApplicationExecute(updateAuthenticationApiApplication)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating an Authentication Api Application", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating an Authentication Api Application", err, httpResp, &customId)
 		return
 	}
 
@@ -243,7 +244,7 @@ func (r *authenticationApiApplicationResource) Update(ctx context.Context, req r
 	if internaltypes.IsDefined(plan.ClientForRedirectlessModeRef) {
 		updateAuthenticationApiApplicationResponse, httpResp, err = r.apiClient.AuthenticationApiAPI.GetApplication(config.AuthContext(ctx, r.providerConfig), plan.ApplicationId.ValueString()).Execute()
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an Authentication Api Application", err, httpResp, &customId)
 		}
 	}
 
@@ -266,7 +267,7 @@ func (r *authenticationApiApplicationResource) Delete(ctx context.Context, req r
 	}
 	httpResp, err := r.apiClient.AuthenticationApiAPI.DeleteApplication(config.AuthContext(ctx, r.providerConfig), state.ApplicationId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an Authentication Api Application", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an Authentication Api Application", err, httpResp, &customId)
 		return
 	}
 

--- a/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_resource.go
+++ b/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_resource.go
@@ -40,6 +40,8 @@ var (
 	coreAttributesDefaultObjValue, _ = types.ObjectValue(coreAttributesDefaultObjAttrType, coreAttributesDefaultObjAttrValue)
 	coreAttributesDefaultListAttrVal = []attr.Value{coreAttributesDefaultObjValue}
 	coreAttributesDefaultListVal, _  = types.ListValue(attributeElemAttrType, coreAttributesDefaultListAttrVal)
+
+	customId = "contract_id"
 )
 
 // AuthenticationPolicyContractResource is a helper function to simplify the provider implementation.
@@ -180,7 +182,7 @@ func (r *authenticationPolicyContractResource) Create(ctx context.Context, req r
 	apiCreateAuthenticationPolicyContracts = apiCreateAuthenticationPolicyContracts.Body(*createAuthenticationPolicyContracts)
 	authenticationPolicyContractsResponse, httpResp, err := r.apiClient.AuthenticationPolicyContractsAPI.CreateAuthenticationPolicyContractExecute(apiCreateAuthenticationPolicyContracts)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating an authentication policy contract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating an authentication policy contract", err, httpResp, &customId)
 		return
 	}
 
@@ -207,7 +209,8 @@ func (r *authenticationPolicyContractResource) Read(ctx context.Context, req res
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Authentication Policy Contract", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an authentication policy contract", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an authentication policy contract", err, httpResp, &customId)
+
 		}
 		return
 	}
@@ -244,7 +247,7 @@ func (r *authenticationPolicyContractResource) Update(ctx context.Context, req r
 	updateAuthenticationPolicyContracts = updateAuthenticationPolicyContracts.Body(*createUpdateRequest)
 	updateAuthenticationPolicyContractsResponse, httpResp, err := r.apiClient.AuthenticationPolicyContractsAPI.UpdateAuthenticationPolicyContractExecute(updateAuthenticationPolicyContracts)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating an authentication policy contract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating an authentication policy contract", err, httpResp, &customId)
 		return
 	}
 
@@ -268,7 +271,7 @@ func (r *authenticationPolicyContractResource) Delete(ctx context.Context, req r
 	}
 	httpResp, err := r.apiClient.AuthenticationPolicyContractsAPI.DeleteAuthenticationPolicyContract(config.AuthContext(ctx, r.providerConfig), state.ContractId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an authentication policy contract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an authentication policy contract", err, httpResp, &customId)
 	}
 
 }

--- a/internal/resource/config/authenticationselector/authentication_selector_resource.go
+++ b/internal/resource/config/authenticationselector/authentication_selector_resource.go
@@ -36,6 +36,8 @@ var (
 				"name": types.StringType,
 			}}},
 	}
+
+	customId = "selector_id"
 )
 
 // AuthenticationSelectorsResource is a helper function to simplify the provider implementation.
@@ -230,7 +232,7 @@ func (r *authenticationSelectorResource) Create(ctx context.Context, req resourc
 	apiCreateAuthenticationSelectors = apiCreateAuthenticationSelectors.Body(*createAuthenticationSelectors)
 	authenticationSelectorResponse, httpResp, err := r.apiClient.AuthenticationSelectorsAPI.CreateAuthenticationSelectorExecute(apiCreateAuthenticationSelectors)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the Authentication Selector", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the Authentication Selector", err, httpResp, &customId)
 		return
 	}
 
@@ -261,7 +263,7 @@ func (r *authenticationSelectorResource) Read(ctx context.Context, req resource.
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Authentication Selector", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Authentication Selector", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the Authentication Selector", err, httpResp, &customId)
 		}
 		return
 	}
@@ -318,7 +320,7 @@ func (r *authenticationSelectorResource) Update(ctx context.Context, req resourc
 	updateAuthenticationSelectors = updateAuthenticationSelectors.Body(*createUpdateRequest)
 	updateAuthenticationSelectorsResponse, httpResp, err := r.apiClient.AuthenticationSelectorsAPI.UpdateAuthenticationSelectorExecute(updateAuthenticationSelectors)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating an Authentication Selector", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating an Authentication Selector", err, httpResp, &customId)
 		return
 	}
 
@@ -342,7 +344,7 @@ func (r *authenticationSelectorResource) Delete(ctx context.Context, req resourc
 	}
 	httpResp, err := r.apiClient.AuthenticationSelectorsAPI.DeleteAuthenticationSelector(config.AuthContext(ctx, r.providerConfig), state.SelectorId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an Authentication Selector", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an Authentication Selector", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/captchaproviders/captcha_provider_resource_gen.go
+++ b/internal/resource/config/captchaproviders/captcha_provider_resource_gen.go
@@ -26,6 +26,8 @@ var (
 	_ resource.Resource                = &captchaProviderResource{}
 	_ resource.ResourceWithConfigure   = &captchaProviderResource{}
 	_ resource.ResourceWithImportState = &captchaProviderResource{}
+
+	customId = "provider_id"
 )
 
 func CaptchaProviderResource() resource.Resource {
@@ -216,7 +218,7 @@ func (r *captchaProviderResource) Create(ctx context.Context, req resource.Creat
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.CaptchaProvidersAPI.CreateCaptchaProviderExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the captchaProvider", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the captchaProvider", err, httpResp, &customId)
 		return
 	}
 
@@ -247,7 +249,7 @@ func (r *captchaProviderResource) Read(ctx context.Context, req resource.ReadReq
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Captcha Provider", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the captchaProvider", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the captchaProvider", err, httpResp, &customId)
 		}
 		return
 	}
@@ -276,7 +278,7 @@ func (r *captchaProviderResource) Update(ctx context.Context, req resource.Updat
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.CaptchaProvidersAPI.UpdateCaptchaProviderExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the captchaProvider", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the captchaProvider", err, httpResp, &customId)
 		return
 	}
 
@@ -300,7 +302,7 @@ func (r *captchaProviderResource) Delete(ctx context.Context, req resource.Delet
 	// Delete API call logic
 	httpResp, err := r.apiClient.CaptchaProvidersAPI.DeleteCaptchaProvider(config.AuthContext(ctx, r.providerConfig), data.ProviderId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the captchaProvider", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the captchaProvider", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/certificates/ca/certificate_ca_resource.go
+++ b/internal/resource/config/certificates/ca/certificate_ca_resource.go
@@ -24,6 +24,8 @@ import (
 var (
 	_ resource.Resource              = &certificateCAResource{}
 	_ resource.ResourceWithConfigure = &certificateCAResource{}
+
+	customId = "ca_id"
 )
 
 // CertificateCAResource is a helper function to simplify the provider implementation.
@@ -222,7 +224,7 @@ func (r *certificateCAResource) Create(ctx context.Context, req resource.CreateR
 	apiCreateCertificate = apiCreateCertificate.Body(*createCertificate)
 	certificateResponse, httpResp, err := r.apiClient.CertificatesCaAPI.ImportTrustedCAExecute(apiCreateCertificate)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating a CA Certificate", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating a CA Certificate", err, httpResp, &customId)
 		return
 	}
 
@@ -248,7 +250,7 @@ func (r *certificateCAResource) Read(ctx context.Context, req resource.ReadReque
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Certificate CA", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while looking for a Certificate", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while looking for a Certificate", err, httpResp, &customId)
 		}
 		return
 	}
@@ -278,7 +280,7 @@ func (r *certificateCAResource) Delete(ctx context.Context, req resource.DeleteR
 
 	httpResp, err := r.apiClient.CertificatesCaAPI.DeleteTrustedCA(config.AuthContext(ctx, r.providerConfig), state.CaId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting a CA Certificate", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting a CA Certificate", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/datastore/custom_data_store.go
+++ b/internal/resource/config/datastore/custom_data_store.go
@@ -236,7 +236,7 @@ func createCustomDataStore(plan dataStoreModel, con context.Context, req resourc
 
 	response, httpResponse, err := createDataStore(createCustomDataStore, dsr, con, resp)
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse, &customId)
 		return
 	}
 	// Read the response into the state
@@ -275,7 +275,7 @@ func updateCustomDataStore(plan dataStoreModel, con context.Context, req resourc
 
 	response, httpResponse, err := updateDataStore(updateCustomDataStore, dsr, con, resp, plan.Id.ValueString())
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse, &customId)
 		return
 	}
 	// Read the response

--- a/internal/resource/config/datastore/data_store_resource.go
+++ b/internal/resource/config/datastore/data_store_resource.go
@@ -30,6 +30,8 @@ var (
 	_ resource.Resource                = &dataStoreResource{}
 	_ resource.ResourceWithConfigure   = &dataStoreResource{}
 	_ resource.ResourceWithImportState = &dataStoreResource{}
+
+	customId = "data_store_id"
 )
 
 func DataStoreResource() resource.Resource {
@@ -403,7 +405,7 @@ func (r *dataStoreResource) Read(ctx context.Context, req resource.ReadRequest, 
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Data Store", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the data store", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the data store", err, httpResp, &customId)
 		}
 		return
 	}
@@ -478,7 +480,7 @@ func (r *dataStoreResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 	httpResp, err := r.apiClient.DataStoresAPI.DeleteDataStore(config.AuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting a data store", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting a data store", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/datastore/jdbc_data_store.go
+++ b/internal/resource/config/datastore/jdbc_data_store.go
@@ -452,7 +452,7 @@ func createJdbcDataStore(plan dataStoreModel, con context.Context, req resource.
 
 	response, httpResponse, err := createDataStore(createJdbcDataStore, dsr, con, resp)
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse, &customId)
 		return
 	}
 
@@ -480,7 +480,7 @@ func updateJdbcDataStore(plan dataStoreModel, con context.Context, req resource.
 
 	response, httpResponse, err := updateDataStore(updateJdbcDataStore, dsr, con, resp, plan.Id.ValueString())
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse, &customId)
 		return
 	}
 

--- a/internal/resource/config/datastore/ldap_data_store.go
+++ b/internal/resource/config/datastore/ldap_data_store.go
@@ -799,7 +799,7 @@ func createLdapDataStore(plan dataStoreModel, con context.Context, req resource.
 
 	response, httpResponse, err := createDataStore(createLdapDataStore, dsr, con, resp)
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse, &customId)
 		return
 	}
 
@@ -826,7 +826,7 @@ func updateLdapDataStore(plan dataStoreModel, con context.Context, req resource.
 
 	response, httpResponse, err := updateDataStore(updateLdapDataStore, dsr, con, resp, plan.Id.ValueString())
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResponse, &customId)
 		return
 	}
 

--- a/internal/resource/config/datastore/ping_one_ldap_gateway_data_store.go
+++ b/internal/resource/config/datastore/ping_one_ldap_gateway_data_store.go
@@ -288,7 +288,7 @@ func createPingOneLdapGatewayDataStore(plan dataStoreModel, con context.Context,
 
 	response, httpResponse, err := createDataStore(createPingOneLdapGatewayDataStore, dsr, con, resp)
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while creating the DataStore", err, httpResponse, &customId)
 		return
 	}
 
@@ -329,7 +329,7 @@ func updatePingOneLdapGatewayDataStore(plan dataStoreModel, con context.Context,
 
 	response, httpResp, err := updateDataStore(updatePingOneLdapGatewayDataStore, dsr, con, resp, plan.Id.ValueString())
 	if err != nil {
-		config.ReportHttpError(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResp)
+		config.ReportHttpErrorCustomId(con, &resp.Diagnostics, "An error occurred while updating the DataStore", err, httpResp, &customId)
 		return
 	}
 

--- a/internal/resource/config/idp/adapter/idp_adapter_resource.go
+++ b/internal/resource/config/idp/adapter/idp_adapter_resource.go
@@ -35,6 +35,8 @@ var (
 	_ resource.Resource                = &idpAdapterResource{}
 	_ resource.ResourceWithConfigure   = &idpAdapterResource{}
 	_ resource.ResourceWithImportState = &idpAdapterResource{}
+
+	customId = "adapter_id"
 )
 
 // IdpAdapterResource is a helper function to simplify the provider implementation.
@@ -329,7 +331,7 @@ func (r *idpAdapterResource) Create(ctx context.Context, req resource.CreateRequ
 	apiCreateIdpAdapter = apiCreateIdpAdapter.Body(*createIdpAdapter)
 	idpAdapterResponse, httpResp, err := r.apiClient.IdpAdaptersAPI.CreateIdpAdapterExecute(apiCreateIdpAdapter)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the IdpAdapter", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the IdpAdapter", err, httpResp, &customId)
 		return
 	}
 
@@ -360,7 +362,7 @@ func (r *idpAdapterResource) Read(ctx context.Context, req resource.ReadRequest,
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "IdP Adapter", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an IdpAdapter", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an IdpAdapter", err, httpResp, &customId)
 		}
 		return
 	}
@@ -412,7 +414,7 @@ func (r *idpAdapterResource) Update(ctx context.Context, req resource.UpdateRequ
 	updateIdpAdapter = updateIdpAdapter.Body(*createUpdateRequest)
 	updateIdpAdapterResponse, httpResp, err := r.apiClient.IdpAdaptersAPI.UpdateIdpAdapterExecute(updateIdpAdapter)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating IdpAdapter", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating IdpAdapter", err, httpResp, &customId)
 		return
 	}
 
@@ -438,7 +440,7 @@ func (r *idpAdapterResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 	httpResp, err := r.apiClient.IdpAdaptersAPI.DeleteIdpAdapter(config.AuthContext(ctx, r.providerConfig), state.AdapterId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the IdP adapter", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the IdP adapter", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
+++ b/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
@@ -45,6 +45,8 @@ var (
 	_ resource.Resource                = &idpSpConnectionResource{}
 	_ resource.ResourceWithConfigure   = &idpSpConnectionResource{}
 	_ resource.ResourceWithImportState = &idpSpConnectionResource{}
+
+	customId = "connection_id"
 )
 
 var (
@@ -3787,7 +3789,7 @@ func (r *idpSpConnectionResource) Create(ctx context.Context, req resource.Creat
 	apiCreateIdpSpconnection = apiCreateIdpSpconnection.Body(*createIdpSpconnection)
 	idpSpconnectionResponse, httpResp, err := r.apiClient.IdpSpConnectionsAPI.CreateSpConnectionExecute(apiCreateIdpSpconnection)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the IdP SP Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the IdP SP Connection", err, httpResp, &customId)
 		return
 	}
 
@@ -3817,7 +3819,7 @@ func (r *idpSpConnectionResource) Read(ctx context.Context, req resource.ReadReq
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "IdP SP Connection", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the IdP SP Connection", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the IdP SP Connection", err, httpResp, &customId)
 		}
 		return
 	}
@@ -3851,7 +3853,7 @@ func (r *idpSpConnectionResource) Update(ctx context.Context, req resource.Updat
 	updateIdpSpconnection = updateIdpSpconnection.Body(*createUpdateRequest)
 	updateIdpSpconnectionResponse, httpResp, err := r.apiClient.IdpSpConnectionsAPI.UpdateSpConnectionExecute(updateIdpSpconnection)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the IdP SP Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the IdP SP Connection", err, httpResp, &customId)
 		return
 	}
 
@@ -3874,7 +3876,7 @@ func (r *idpSpConnectionResource) Delete(ctx context.Context, req resource.Delet
 	}
 	httpResp, err := r.apiClient.IdpSpConnectionsAPI.DeleteSpConnection(config.AuthContext(ctx, r.providerConfig), state.ConnectionId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the IdP SP Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the IdP SP Connection", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/idp/stsrequestparameterscontracts/idp_sts_request_parameters_contract_resource_gen.go
+++ b/internal/resource/config/idp/stsrequestparameterscontracts/idp_sts_request_parameters_contract_resource_gen.go
@@ -24,6 +24,8 @@ var (
 	_ resource.Resource                = &idpStsRequestParametersContractResource{}
 	_ resource.ResourceWithConfigure   = &idpStsRequestParametersContractResource{}
 	_ resource.ResourceWithImportState = &idpStsRequestParametersContractResource{}
+
+	customId = "contract_id"
 )
 
 func IdpStsRequestParametersContractResource() resource.Resource {
@@ -136,7 +138,7 @@ func (r *idpStsRequestParametersContractResource) Create(ctx context.Context, re
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.IdpStsRequestParametersContractsAPI.CreateStsRequestParamContractExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the idpStsRequestParametersContract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the idpStsRequestParametersContract", err, httpResp, &customId)
 		return
 	}
 
@@ -164,7 +166,7 @@ func (r *idpStsRequestParametersContractResource) Read(ctx context.Context, req 
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "IdP STS Request Parameters Contract", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the idpStsRequestParametersContract", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the idpStsRequestParametersContract", err, httpResp, &customId)
 		}
 		return
 	}
@@ -193,7 +195,7 @@ func (r *idpStsRequestParametersContractResource) Update(ctx context.Context, re
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.IdpStsRequestParametersContractsAPI.UpdateStsRequestParamContractByIdExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the idpStsRequestParametersContract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the idpStsRequestParametersContract", err, httpResp, &customId)
 		return
 	}
 
@@ -217,7 +219,7 @@ func (r *idpStsRequestParametersContractResource) Delete(ctx context.Context, re
 	// Delete API call logic
 	httpResp, err := r.apiClient.IdpStsRequestParametersContractsAPI.DeleteStsRequestParamContractById(config.AuthContext(ctx, r.providerConfig), data.ContractId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the idpStsRequestParametersContract", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the idpStsRequestParametersContract", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/kerberos/realms/kerberos_realm_resource.go
+++ b/internal/resource/config/kerberos/realms/kerberos_realm_resource.go
@@ -29,6 +29,8 @@ var (
 	_ resource.ResourceWithImportState = &kerberosRealmsResource{}
 
 	emptyStringSet, _ = types.SetValue(types.StringType, nil)
+
+	customId = "realm_id"
 )
 
 // KerberosRealmsResource is a helper function to simplify the provider implementation.
@@ -273,7 +275,7 @@ func (r *kerberosRealmsResource) Create(ctx context.Context, req resource.Create
 	apiCreateKerberosRealms = apiCreateKerberosRealms.Body(*createKerberosRealms)
 	kerberosRealmsResponse, httpResp, err := r.apiClient.KerberosRealmsAPI.CreateKerberosRealmExecute(apiCreateKerberosRealms)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating a kerberos realm", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating a kerberos realm", err, httpResp, &customId)
 		return
 	}
 
@@ -301,7 +303,7 @@ func (r *kerberosRealmsResource) Read(ctx context.Context, req resource.ReadRequ
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Kerberos Realm", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting a kerberos realm", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting a kerberos realm", err, httpResp, &customId)
 		}
 		return
 	}
@@ -335,7 +337,7 @@ func (r *kerberosRealmsResource) Update(ctx context.Context, req resource.Update
 	updateKerberosRealms = updateKerberosRealms.Body(*createUpdateRequest)
 	updateKerberosRealmsResponse, httpResp, err := r.apiClient.KerberosRealmsAPI.UpdateKerberosRealmExecute(updateKerberosRealms)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating a kerberos realm", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating a kerberos realm", err, httpResp, &customId)
 		return
 	}
 
@@ -358,7 +360,7 @@ func (r *kerberosRealmsResource) Delete(ctx context.Context, req resource.Delete
 	}
 	httpResp, err := r.apiClient.KerberosRealmsAPI.DeleteKerberosRealm(config.AuthContext(ctx, r.providerConfig), state.RealmId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting a kerberos realm", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting a kerberos realm", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/keypairs/oauthopenidconnect/additionalkeysets/keypairs_oauth_openid_connect_additional_key_set_resource_gen.go
+++ b/internal/resource/config/keypairs/oauthopenidconnect/additionalkeysets/keypairs_oauth_openid_connect_additional_key_set_resource_gen.go
@@ -27,6 +27,8 @@ var (
 	_ resource.Resource                = &keypairsOauthOpenidConnectAdditionalKeySetResource{}
 	_ resource.ResourceWithConfigure   = &keypairsOauthOpenidConnectAdditionalKeySetResource{}
 	_ resource.ResourceWithImportState = &keypairsOauthOpenidConnectAdditionalKeySetResource{}
+
+	customId = "set_id"
 )
 
 func KeypairsOauthOpenidConnectAdditionalKeySetResource() resource.Resource {
@@ -692,7 +694,7 @@ func (r *keypairsOauthOpenidConnectAdditionalKeySetResource) Create(ctx context.
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.KeyPairsOauthOpenIdConnectAPI.CreateKeySetExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp, &customId)
 		return
 	}
 
@@ -720,7 +722,7 @@ func (r *keypairsOauthOpenidConnectAdditionalKeySetResource) Read(ctx context.Co
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Additional Key Set", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp, &customId)
 		}
 		return
 	}
@@ -760,7 +762,7 @@ func (r *keypairsOauthOpenidConnectAdditionalKeySetResource) Update(ctx context.
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.KeyPairsOauthOpenIdConnectAPI.UpdateKeySetExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp, &customId)
 		return
 	}
 
@@ -784,7 +786,7 @@ func (r *keypairsOauthOpenidConnectAdditionalKeySetResource) Delete(ctx context.
 	// Delete API call logic
 	httpResp, err := r.apiClient.KeyPairsOauthOpenIdConnectAPI.DeleteKeySet(config.AuthContext(ctx, r.providerConfig), data.SetId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the keypairsOauthOpenidConnectAdditionalKeySet", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/keypairs/signing/keypairs_signing_key_resource.go
+++ b/internal/resource/config/keypairs/signing/keypairs_signing_key_resource.go
@@ -26,6 +26,8 @@ import (
 var (
 	_ resource.Resource              = &keypairsSigningKeyResource{}
 	_ resource.ResourceWithConfigure = &keypairsSigningKeyResource{}
+
+	customId = "key_id"
 )
 
 // KeypairsSigningKeyResource is a helper function to simplify the provider implementation.
@@ -540,7 +542,7 @@ func (r *keypairsSigningKeyResource) Create(ctx context.Context, req resource.Cr
 		apiCreateRequest = apiCreateRequest.Body(*clientData)
 		responseData, httpResp, err = r.apiClient.KeyPairsSigningAPI.CreateSigningKeyPairExecute(apiCreateRequest)
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while generating the signing key", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while generating the signing key", err, httpResp, &customId)
 			return
 		}
 	} else {
@@ -550,7 +552,7 @@ func (r *keypairsSigningKeyResource) Create(ctx context.Context, req resource.Cr
 		apiCreateRequest = apiCreateRequest.Body(*clientData)
 		responseData, httpResp, err = r.apiClient.KeyPairsSigningAPI.ImportSigningKeyPairExecute(apiCreateRequest)
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while importing the signing key", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while importing the signing key", err, httpResp, &customId)
 			return
 		}
 	}
@@ -579,7 +581,7 @@ func (r *keypairsSigningKeyResource) Read(ctx context.Context, req resource.Read
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Signing Key Pair", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the key pair", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the key pair", err, httpResp, &customId)
 		}
 		return
 	}
@@ -610,6 +612,6 @@ func (r *keypairsSigningKeyResource) Delete(ctx context.Context, req resource.De
 	// Delete API call logic
 	httpResp, err := r.apiClient.KeyPairsSigningAPI.DeleteSigningKeyPair(config.AuthContext(ctx, r.providerConfig), data.KeyId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the signing key", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the signing key", err, httpResp, &customId)
 	}
 }

--- a/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_resource.go
+++ b/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_resource.go
@@ -26,6 +26,8 @@ import (
 var (
 	_ resource.Resource              = &keypairsSslServerKeyResource{}
 	_ resource.ResourceWithConfigure = &keypairsSslServerKeyResource{}
+
+	customId = "key_id"
 )
 
 // KeypairsSslServerKeyResource is a helper function to simplify the provider implementation.
@@ -540,7 +542,7 @@ func (r *keypairsSslServerKeyResource) Create(ctx context.Context, req resource.
 		apiCreateRequest = apiCreateRequest.Body(*clientData)
 		responseData, httpResp, err = r.apiClient.KeyPairsSslServerAPI.CreateSslServerKeyPairExecute(apiCreateRequest)
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while generating the ssl server key", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while generating the ssl server key", err, httpResp, &customId)
 			return
 		}
 	} else {
@@ -550,7 +552,7 @@ func (r *keypairsSslServerKeyResource) Create(ctx context.Context, req resource.
 		apiCreateRequest = apiCreateRequest.Body(*clientData)
 		responseData, httpResp, err = r.apiClient.KeyPairsSslServerAPI.ImportSslServerKeyPairExecute(apiCreateRequest)
 		if err != nil {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while importing the ssl server key", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while importing the ssl server key", err, httpResp, &customId)
 			return
 		}
 	}
@@ -579,7 +581,7 @@ func (r *keypairsSslServerKeyResource) Read(ctx context.Context, req resource.Re
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "SSL Server Key Pair", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the key pair", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the key pair", err, httpResp, &customId)
 		}
 		return
 	}
@@ -610,6 +612,6 @@ func (r *keypairsSslServerKeyResource) Delete(ctx context.Context, req resource.
 	// Delete API call logic
 	httpResp, err := r.apiClient.KeyPairsSslServerAPI.DeleteSslServerKeyPair(config.AuthContext(ctx, r.providerConfig), data.KeyId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the ssl server key", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the ssl server key", err, httpResp, &customId)
 	}
 }

--- a/internal/resource/config/localidentity/identityprofile/local_identity_profile_resource.go
+++ b/internal/resource/config/localidentity/identityprofile/local_identity_profile_resource.go
@@ -36,6 +36,8 @@ var (
 	_ resource.Resource                = &localIdentityProfileResource{}
 	_ resource.ResourceWithConfigure   = &localIdentityProfileResource{}
 	_ resource.ResourceWithImportState = &localIdentityProfileResource{}
+
+	customId = "profile_id"
 )
 
 var (
@@ -1043,7 +1045,7 @@ func (r *localIdentityProfileResource) Create(ctx context.Context, req resource.
 	apiCreateLocalIdentityProfiles = apiCreateLocalIdentityProfiles.Body(*createLocalIdentityProfiles)
 	localIdentityProfilesResponse, httpResp, err := r.apiClient.LocalIdentityIdentityProfilesAPI.CreateIdentityProfileExecute(apiCreateLocalIdentityProfiles)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the local identity profiles", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the local identity profiles", err, httpResp, &customId)
 		return
 	}
 
@@ -1070,7 +1072,7 @@ func (r *localIdentityProfileResource) Read(ctx context.Context, req resource.Re
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Local Identity Profile", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the local identity profile", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the local identity profile", err, httpResp, &customId)
 		}
 		return
 	}
@@ -1108,7 +1110,7 @@ func (r *localIdentityProfileResource) Update(ctx context.Context, req resource.
 	updateLocalIdentityProfiles = updateLocalIdentityProfiles.Body(*createUpdateRequest)
 	updateLocalIdentityProfilesResponse, httpResp, err := r.apiClient.LocalIdentityIdentityProfilesAPI.UpdateIdentityProfileExecute(updateLocalIdentityProfiles)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating a local identity profile", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating a local identity profile", err, httpResp, &customId)
 		return
 	}
 
@@ -1131,7 +1133,7 @@ func (r *localIdentityProfileResource) Delete(ctx context.Context, req resource.
 	}
 	httpResp, err := r.apiClient.LocalIdentityIdentityProfilesAPI.DeleteIdentityProfile(config.AuthContext(ctx, r.providerConfig), state.ProfileId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the local identity profile", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the local identity profile", err, httpResp, &customId)
 	}
 
 }

--- a/internal/resource/config/metadataurls/metadata_url_resource_gen.go
+++ b/internal/resource/config/metadataurls/metadata_url_resource_gen.go
@@ -27,6 +27,8 @@ var (
 	_ resource.Resource                = &metadataUrlResource{}
 	_ resource.ResourceWithConfigure   = &metadataUrlResource{}
 	_ resource.ResourceWithImportState = &metadataUrlResource{}
+
+	customId = "url_id"
 )
 
 func MetadataUrlResource() resource.Resource {
@@ -314,7 +316,7 @@ func (r *metadataUrlResource) Create(ctx context.Context, req resource.CreateReq
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.MetadataUrlsAPI.AddMetadataUrlExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the metadataUrl", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the metadataUrl", err, httpResp, &customId)
 		return
 	}
 
@@ -342,7 +344,7 @@ func (r *metadataUrlResource) Read(ctx context.Context, req resource.ReadRequest
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Metadata URL", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the metadataUrl", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the metadataUrl", err, httpResp, &customId)
 		}
 		return
 	}
@@ -371,7 +373,7 @@ func (r *metadataUrlResource) Update(ctx context.Context, req resource.UpdateReq
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.MetadataUrlsAPI.UpdateMetadataUrlExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the metadataUrl", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the metadataUrl", err, httpResp, &customId)
 		return
 	}
 
@@ -395,7 +397,7 @@ func (r *metadataUrlResource) Delete(ctx context.Context, req resource.DeleteReq
 	// Delete API call logic
 	httpResp, err := r.apiClient.MetadataUrlsAPI.DeleteMetadataUrl(config.AuthContext(ctx, r.providerConfig), data.UrlId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the metadataUrl", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the metadataUrl", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/notificationpublishers/notification_publisher_resource_gen.go
+++ b/internal/resource/config/notificationpublishers/notification_publisher_resource_gen.go
@@ -26,6 +26,8 @@ var (
 	_ resource.Resource                = &notificationPublisherResource{}
 	_ resource.ResourceWithConfigure   = &notificationPublisherResource{}
 	_ resource.ResourceWithImportState = &notificationPublisherResource{}
+
+	customId = "publisher_id"
 )
 
 func NotificationPublisherResource() resource.Resource {
@@ -214,7 +216,7 @@ func (r *notificationPublisherResource) Create(ctx context.Context, req resource
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.NotificationPublishersAPI.CreateNotificationPublisherExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the notificationPublisher", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the notificationPublisher", err, httpResp, &customId)
 		return
 	}
 
@@ -245,7 +247,7 @@ func (r *notificationPublisherResource) Read(ctx context.Context, req resource.R
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Notification Publisher", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the notificationPublisher", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the notificationPublisher", err, httpResp, &customId)
 		}
 		return
 	}
@@ -274,7 +276,7 @@ func (r *notificationPublisherResource) Update(ctx context.Context, req resource
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.NotificationPublishersAPI.UpdateNotificationPublisherExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the notificationPublisher", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the notificationPublisher", err, httpResp, &customId)
 		return
 	}
 
@@ -298,7 +300,7 @@ func (r *notificationPublisherResource) Delete(ctx context.Context, req resource
 	// Delete API call logic
 	httpResp, err := r.apiClient.NotificationPublishersAPI.DeleteNotificationPublisher(config.AuthContext(ctx, r.providerConfig), data.PublisherId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the notificationPublisher", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the notificationPublisher", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource.go
+++ b/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource.go
@@ -82,6 +82,8 @@ var (
 		"check_session_revocation_status": types.BoolValue(false),
 		"update_authn_session_activity":   types.BoolValue(false),
 	})
+
+	customId = "manager_id"
 )
 
 // OauthAccessTokenManagerResource is a helper function to simplify the provider implementation.
@@ -505,7 +507,7 @@ func (r *oauthAccessTokenManagerResource) Create(ctx context.Context, req resour
 	apiCreateOauthAccessTokenManager = apiCreateOauthAccessTokenManager.Body(*createOauthAccessTokenManager)
 	oauthAccessTokenManagerResponse, httpResp, err := r.apiClient.OauthAccessTokenManagersAPI.CreateTokenManagerExecute(apiCreateOauthAccessTokenManager)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the OAuth Access Token Manager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the OAuth Access Token Manager", err, httpResp, &customId)
 		return
 	}
 
@@ -537,7 +539,7 @@ func (r *oauthAccessTokenManagerResource) Read(ctx context.Context, req resource
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "OAuth Access Token Manager", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the OAuth Access Token Manager", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the OAuth Access Token Manager", err, httpResp, &customId)
 		}
 		return
 	}
@@ -593,7 +595,7 @@ func (r *oauthAccessTokenManagerResource) Update(ctx context.Context, req resour
 	updateOauthAccessTokenManager = updateOauthAccessTokenManager.Body(*createUpdateRequest)
 	updateOauthAccessTokenManagerResponse, httpResp, err := r.apiClient.OauthAccessTokenManagersAPI.UpdateTokenManagerExecute(updateOauthAccessTokenManager)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating an OAuth access token manager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating an OAuth access token manager", err, httpResp, &customId)
 		return
 	}
 
@@ -618,7 +620,7 @@ func (r *oauthAccessTokenManagerResource) Delete(ctx context.Context, req resour
 	}
 	httpResp, err := r.apiClient.OauthAccessTokenManagersAPI.DeleteTokenManager(config.AuthContext(ctx, r.providerConfig), state.ManagerId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth access token manager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth access token manager", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/oauth/client/oauth_client_resource.go
+++ b/internal/resource/config/oauth/client/oauth_client_resource.go
@@ -49,6 +49,8 @@ var (
 	oidcPolicyDefaultObj, _     = types.ObjectValue(oidcPolicyAttrType, oidcPolicyDefaultAttrValue)
 	secondarySecretsEmptySet, _ = types.SetValue(types.ObjectType{AttrTypes: secondarySecretsAttrType}, []attr.Value{})
 	clientAuthDefaultObj, _     = types.ObjectValue(clientAuthAttrType, clientAuthDefaultAttrValue)
+
+	customId = "client_id"
 )
 
 // OauthClientResource is a helper function to simplify the provider implementation.
@@ -1436,7 +1438,7 @@ func (r *oauthClientResource) Create(ctx context.Context, req resource.CreateReq
 	apiCreateOauthClient = apiCreateOauthClient.Body(*createOauthClient)
 	oauthClientResponse, httpResp, err := r.apiClient.OauthClientsAPI.CreateOauthClientExecute(apiCreateOauthClient)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the OAuth Client", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the OAuth Client", err, httpResp, &customId)
 		return
 	}
 
@@ -1467,7 +1469,7 @@ func (r *oauthClientResource) Read(ctx context.Context, req resource.ReadRequest
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "OAuth Client", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the  OAuth Client", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the  OAuth Client", err, httpResp, &customId)
 		}
 		return
 	}
@@ -1502,7 +1504,7 @@ func (r *oauthClientResource) Update(ctx context.Context, req resource.UpdateReq
 	updateOauthClient = updateOauthClient.Body(*createUpdateRequest)
 	updateOauthClientResponse, httpResp, err := r.apiClient.OauthClientsAPI.UpdateOauthClientExecute(updateOauthClient)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the OAuth Client", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the OAuth Client", err, httpResp, &customId)
 		return
 	}
 
@@ -1526,7 +1528,7 @@ func (r *oauthClientResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 	httpResp, err := r.apiClient.OauthClientsAPI.DeleteOauthClient(config.AuthContext(ctx, r.providerConfig), state.ClientId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth Client", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth Client", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen.go
+++ b/internal/resource/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen.go
@@ -25,6 +25,8 @@ var (
 	_ resource.Resource                = &oauthIdpAdapterMappingResource{}
 	_ resource.ResourceWithConfigure   = &oauthIdpAdapterMappingResource{}
 	_ resource.ResourceWithImportState = &oauthIdpAdapterMappingResource{}
+
+	customId = "mapping_id"
 )
 
 func OauthIdpAdapterMappingResource() resource.Resource {
@@ -174,7 +176,7 @@ func (r *oauthIdpAdapterMappingResource) Create(ctx context.Context, req resourc
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.OauthIdpAdapterMappingsAPI.CreateIdpAdapterMappingExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the oauthIdpAdapterMapping", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the oauthIdpAdapterMapping", err, httpResp, &customId)
 		return
 	}
 
@@ -202,7 +204,7 @@ func (r *oauthIdpAdapterMappingResource) Read(ctx context.Context, req resource.
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "OAuth IdP Adapter Mapping", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the oauthIdpAdapterMapping", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the oauthIdpAdapterMapping", err, httpResp, &customId)
 		}
 		return
 	}
@@ -234,7 +236,7 @@ func (r *oauthIdpAdapterMappingResource) Update(ctx context.Context, req resourc
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.OauthIdpAdapterMappingsAPI.UpdateIdpAdapterMappingExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the oauthIdpAdapterMapping", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the oauthIdpAdapterMapping", err, httpResp, &customId)
 		return
 	}
 
@@ -258,7 +260,7 @@ func (r *oauthIdpAdapterMappingResource) Delete(ctx context.Context, req resourc
 	// Delete API call logic
 	httpResp, err := r.apiClient.OauthIdpAdapterMappingsAPI.DeleteIdpAdapterMapping(config.AuthContext(ctx, r.providerConfig), data.MappingId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the oauthIdpAdapterMapping", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the oauthIdpAdapterMapping", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/oauth/issuer/oauth_issuer_resource.go
+++ b/internal/resource/config/oauth/issuer/oauth_issuer_resource.go
@@ -22,6 +22,8 @@ var (
 	_ resource.Resource                = &oauthIssuerResource{}
 	_ resource.ResourceWithConfigure   = &oauthIssuerResource{}
 	_ resource.ResourceWithImportState = &oauthIssuerResource{}
+
+	customId = "issuer_id"
 )
 
 // OauthIssuerResource is a helper function to simplify the provider implementation.
@@ -140,7 +142,7 @@ func (r *oauthIssuerResource) Create(ctx context.Context, req resource.CreateReq
 	oauthIssuerResponse, httpResp, err := r.apiClient.OauthIssuersAPI.AddOauthIssuerExecute(apiCreateOauthIssuer)
 
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating an OAuth Issuer", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating an OAuth Issuer", err, httpResp, &customId)
 		return
 	}
 
@@ -166,7 +168,7 @@ func (r *oauthIssuerResource) Read(ctx context.Context, req resource.ReadRequest
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "OAuth Issuer", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an OAuth Issuer", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an OAuth Issuer", err, httpResp, &customId)
 		}
 		return
 	}
@@ -203,7 +205,7 @@ func (r *oauthIssuerResource) Update(ctx context.Context, req resource.UpdateReq
 	updateOauthIssuer = updateOauthIssuer.Body(*createUpdateRequest)
 	updateOauthIssuerResponse, httpResp, err := r.apiClient.OauthIssuersAPI.UpdateOauthIssuerExecute(updateOauthIssuer)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating an OAuth Issuer", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating an OAuth Issuer", err, httpResp, &customId)
 		return
 	}
 
@@ -226,7 +228,7 @@ func (r *oauthIssuerResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 	httpResp, err := r.apiClient.OauthIssuersAPI.DeleteOauthIssuer(config.AuthContext(ctx, r.providerConfig), state.IssuerId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth Issuer", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting an OAuth Issuer", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/oauth/openidconnect/policy/openid_connect_policy_resource.go
+++ b/internal/resource/config/oauth/openidconnect/policy/openid_connect_policy_resource.go
@@ -34,6 +34,8 @@ var (
 	_ resource.Resource                = &openidConnectPolicyResource{}
 	_ resource.ResourceWithConfigure   = &openidConnectPolicyResource{}
 	_ resource.ResourceWithImportState = &openidConnectPolicyResource{}
+
+	customId = "policy_id"
 )
 
 // OpenidConnectPolicyResource is a helper function to simplify the provider implementation.
@@ -347,7 +349,7 @@ func (r *openidConnectPolicyResource) Create(ctx context.Context, req resource.C
 	apiCreateOIDCPolicy = apiCreateOIDCPolicy.Body(*newOIDCPolicy)
 	oidcPolicyResponse, httpResp, err := r.apiClient.OauthOpenIdConnectAPI.CreateOIDCPolicyExecute(apiCreateOIDCPolicy)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the OIDC Policy", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the OIDC Policy", err, httpResp, &customId)
 		return
 	}
 
@@ -373,7 +375,7 @@ func (r *openidConnectPolicyResource) Read(ctx context.Context, req resource.Rea
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "OIDC Policy", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting an OIDC Policy", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting an OIDC Policy", err, httpResp, &customId)
 		}
 		return
 	}
@@ -416,7 +418,7 @@ func (r *openidConnectPolicyResource) Update(ctx context.Context, req resource.U
 	updateOIDCPolicyRequest = updateOIDCPolicyRequest.Body(*updatedPolicy)
 	updateResponse, httpResp, err := r.apiClient.OauthOpenIdConnectAPI.UpdateOIDCPolicyExecute(updateOIDCPolicyRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the OIDC Policy", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the OIDC Policy", err, httpResp, &customId)
 		return
 	}
 
@@ -441,7 +443,7 @@ func (r *openidConnectPolicyResource) Delete(ctx context.Context, req resource.D
 	}
 	httpResp, err := r.apiClient.OauthOpenIdConnectAPI.DeleteOIDCPolicy(config.AuthContext(ctx, r.providerConfig), state.PolicyId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the OIDC Policy", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the OIDC Policy", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/passwordcredentialvalidator/password_credential_validator_resource.go
+++ b/internal/resource/config/passwordcredentialvalidator/password_credential_validator_resource.go
@@ -30,6 +30,8 @@ var (
 	_ resource.Resource                = &passwordCredentialValidatorResource{}
 	_ resource.ResourceWithConfigure   = &passwordCredentialValidatorResource{}
 	_ resource.ResourceWithImportState = &passwordCredentialValidatorResource{}
+
+	customId = "validator_id"
 )
 
 // PasswordCredentialValidatorResource is a helper function to simplify the provider implementation.
@@ -316,7 +318,7 @@ func (r *passwordCredentialValidatorResource) Create(ctx context.Context, req re
 	apiCreatePasswordCredentialValidators = apiCreatePasswordCredentialValidators.Body(*createPasswordCredentialValidators)
 	passwordCredentialValidatorsResponse, httpResp, err := r.apiClient.PasswordCredentialValidatorsAPI.CreatePasswordCredentialValidatorExecute(apiCreatePasswordCredentialValidators)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating a Password Credential Validator", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating a Password Credential Validator", err, httpResp, &customId)
 		return
 	}
 
@@ -346,7 +348,7 @@ func (r *passwordCredentialValidatorResource) Read(ctx context.Context, req reso
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Password Credential Validator", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting a Password Credential Validator", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting a Password Credential Validator", err, httpResp, &customId)
 		}
 		return
 	}
@@ -395,7 +397,7 @@ func (r *passwordCredentialValidatorResource) Update(ctx context.Context, req re
 	updatePasswordCredentialValidators = updatePasswordCredentialValidators.Body(*createUpdateRequest)
 	updatePasswordCredentialValidatorsResponse, httpResp, err := r.apiClient.PasswordCredentialValidatorsAPI.UpdatePasswordCredentialValidatorExecute(updatePasswordCredentialValidators)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating a Password Credential Validator", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating a Password Credential Validator", err, httpResp, &customId)
 		return
 	}
 
@@ -418,7 +420,7 @@ func (r *passwordCredentialValidatorResource) Delete(ctx context.Context, req re
 	}
 	httpResp, err := r.apiClient.PasswordCredentialValidatorsAPI.DeletePasswordCredentialValidator(config.AuthContext(ctx, r.providerConfig), state.ValidatorId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting a Password Credential Validator", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting a Password Credential Validator", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/pingoneconnection/pingone_connection_resource.go
+++ b/internal/resource/config/pingoneconnection/pingone_connection_resource.go
@@ -22,6 +22,8 @@ var (
 	_ resource.Resource                = &pingoneConnectionResource{}
 	_ resource.ResourceWithConfigure   = &pingoneConnectionResource{}
 	_ resource.ResourceWithImportState = &pingoneConnectionResource{}
+
+	customId = "connection_id"
 )
 
 // PingoneConnectionResource is a helper function to simplify the provider implementation.
@@ -204,7 +206,7 @@ func (r *pingoneConnectionResource) Create(ctx context.Context, req resource.Cre
 	apiCreatePingOneConnection = apiCreatePingOneConnection.Body(*createPingOneConnection)
 	pingOneConnectionResponse, httpResp, err := r.apiClient.PingOneConnectionsAPI.CreatePingOneConnectionExecute(apiCreatePingOneConnection)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the the PingOne Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the the PingOne Connection", err, httpResp, &customId)
 		return
 	}
 
@@ -232,7 +234,7 @@ func (r *pingoneConnectionResource) Read(ctx context.Context, req resource.ReadR
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "PingOne Connection", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the  the PingOne Connection", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while getting the  the PingOne Connection", err, httpResp, &customId)
 		}
 		return
 	}
@@ -266,7 +268,7 @@ func (r *pingoneConnectionResource) Update(ctx context.Context, req resource.Upd
 	updatePingOneConnection = updatePingOneConnection.Body(*createUpdateRequest)
 	updatePingOneConnectionResponse, httpResp, err := r.apiClient.PingOneConnectionsAPI.UpdatePingOneConnectionExecute(updatePingOneConnection)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the PingOne Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the PingOne Connection", err, httpResp, &customId)
 		return
 	}
 
@@ -289,7 +291,7 @@ func (r *pingoneConnectionResource) Delete(ctx context.Context, req resource.Del
 	}
 	httpResp, err := r.apiClient.PingOneConnectionsAPI.DeletePingOneConnection(config.AuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the PingOne Connection", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the PingOne Connection", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/secretmanagers/secret_manager_resource_gen.go
+++ b/internal/resource/config/secretmanagers/secret_manager_resource_gen.go
@@ -26,6 +26,8 @@ var (
 	_ resource.Resource                = &secretManagerResource{}
 	_ resource.ResourceWithConfigure   = &secretManagerResource{}
 	_ resource.ResourceWithImportState = &secretManagerResource{}
+
+	customId = "manager_id"
 )
 
 func SecretManagerResource() resource.Resource {
@@ -215,7 +217,7 @@ func (r *secretManagerResource) Create(ctx context.Context, req resource.CreateR
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.SecretManagersAPI.CreateSecretManagerExecute(apiCreateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the secretManager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while creating the secretManager", err, httpResp, &customId)
 		return
 	}
 
@@ -246,7 +248,7 @@ func (r *secretManagerResource) Read(ctx context.Context, req resource.ReadReque
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Secret Manager", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while reading the secretManager", err, httpResp)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the secretManager", err, httpResp, &customId)
 		}
 		return
 	}
@@ -275,7 +277,7 @@ func (r *secretManagerResource) Update(ctx context.Context, req resource.UpdateR
 	apiUpdateRequest = apiUpdateRequest.Body(*clientData)
 	responseData, httpResp, err := r.apiClient.SecretManagersAPI.UpdateSecretManagerExecute(apiUpdateRequest)
 	if err != nil {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while updating the secretManager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while updating the secretManager", err, httpResp, &customId)
 		return
 	}
 
@@ -299,7 +301,7 @@ func (r *secretManagerResource) Delete(ctx context.Context, req resource.DeleteR
 	// Delete API call logic
 	httpResp, err := r.apiClient.SecretManagersAPI.DeleteSecretManager(config.AuthContext(ctx, r.providerConfig), data.ManagerId.ValueString()).Execute()
 	if err != nil && (httpResp == nil || httpResp.StatusCode != 404) {
-		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the secretManager", err, httpResp)
+		config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while deleting the secretManager", err, httpResp, &customId)
 	}
 }
 

--- a/internal/resource/config/utils.go
+++ b/internal/resource/config/utils.go
@@ -133,6 +133,7 @@ func ReportHttpErrorCustomId(ctx context.Context, diagnostics *diag.Diagnostics,
 			if internalError == nil {
 				for _, validationError := range pfError.ValidationErrors {
 					var errorDetail strings.Builder
+					errorDetail.WriteString("Message: ")
 					errorDetail.WriteString(validationError.Message)
 					errorDetail.WriteString("\nHTTP status: " + httpResp.Status)
 					if validationError.FieldPath != "" {

--- a/internal/resource/config/utils.go
+++ b/internal/resource/config/utils.go
@@ -6,11 +6,20 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	client "github.com/pingidentity/pingfederate-go-client/v1210/configurationapi"
 	internaltypes "github.com/pingidentity/terraform-provider-pingfederate/internal/types"
+)
+
+var (
+	// lowerOrDigitToUpper will match a sequence of a lowercase letter or digit followed by an uppercase letter
+	lowerOrDigitToUpper = regexp.MustCompile(`([a-z0-9])[A-Z]`)
 )
 
 // Get BasicAuth context with a username and password
@@ -64,10 +73,17 @@ func AuthContext(ctx context.Context, providerConfig internaltypes.ProviderConfi
 }
 
 // Error from PF API
-type pingFederateError struct {
-	Schemas []string `json:"schemas"`
-	Status  string   `json:"status"`
-	Detail  string   `json:"detail"`
+type pingFederateValidationError struct {
+	Message          string `json:"message"`
+	DeveloperMessage string `json:"developerMessage,omitempty"`
+	FieldPath        string `json:"fieldPath"`
+	ErrorId          string `json:"errorId"`
+}
+
+type pingFederateErrorResponse struct {
+	ResultId         string                        `json:"resultId"`
+	Message          string                        `json:"message"`
+	ValidationErrors []pingFederateValidationError `json:"validationErrors"`
 }
 
 // Report a 404 as a warning for resources
@@ -83,25 +99,83 @@ func AddResourceNotFoundWarning(ctx context.Context, diagnostics *diag.Diagnosti
 	}
 }
 
+func toTerraformIdentifier(pfIdentifier string) string {
+	// Insert an underscore between lowercase letter followed by uppercase letter
+	insertedUnderscores := lowerOrDigitToUpper.ReplaceAllStringFunc(pfIdentifier, func(s string) string {
+		firstRune, size := utf8.DecodeRuneInString(s)
+		if firstRune == utf8.RuneError && size <= 1 {
+			// The string is empty, return it
+			return s
+		}
+
+		return fmt.Sprintf("%s_%s", string(firstRune), strings.ToLower(s[size:]))
+	})
+
+	// Lowercase the final string
+	return strings.ToLower(insertedUnderscores)
+}
+
 // Report an HTTP error
 func ReportHttpError(ctx context.Context, diagnostics *diag.Diagnostics, errorSummary string, err error, httpResp *http.Response) {
+	ReportHttpErrorCustomId(ctx, diagnostics, errorSummary, err, httpResp, nil)
+}
+
+// Report an HTTP error
+func ReportHttpErrorCustomId(ctx context.Context, diagnostics *diag.Diagnostics, errorSummary string, err error, httpResp *http.Response, customId *string) {
 	httpErrorPrinted := false
 	var internalError error
 	if httpResp != nil {
 		body, internalError := io.ReadAll(httpResp.Body)
 		if internalError == nil {
 			tflog.Debug(ctx, "Error HTTP response body: "+string(body))
-			var paError pingFederateError
-			internalError = json.Unmarshal(body, &paError)
+			var pfError pingFederateErrorResponse
+			internalError = json.Unmarshal(body, &pfError)
 			if internalError == nil {
+				for _, validationError := range pfError.ValidationErrors {
+					var errorDetail strings.Builder
+					errorDetail.WriteString(validationError.Message)
+					if validationError.FieldPath != "" {
+						errorDetail.WriteString("\nPingFederate field path: ")
+						errorDetail.WriteString(validationError.FieldPath)
+					}
+					if validationError.ErrorId != "" {
+						errorDetail.WriteString("\nError ID: ")
+						errorDetail.WriteString(validationError.ErrorId)
+					}
+					if validationError.DeveloperMessage != "" {
+						errorDetail.WriteString("\nDeveloper message: ")
+						errorDetail.WriteString(validationError.DeveloperMessage)
+					}
+					if validationError.FieldPath != "" {
+						tfFieldPath := validationError.FieldPath
+						if customId != nil && tfFieldPath == "id" {
+							tfFieldPath = *customId
+						}
+						tfAttrName := toTerraformIdentifier(tfFieldPath)
+						// Attempt to build the terraform field path from the attribute name
+						fieldSteps := strings.Split(tfAttrName, ".")
+						var fieldPath path.Path
+						for i, step := range fieldSteps {
+							if i == 0 {
+								fieldPath = path.Root(step)
+							} else {
+								fieldPath = fieldPath.AtMapKey(step)
+							}
+						}
+						diagnostics.AddAttributeError(fieldPath, "PingFederate validation error "+httpResp.Status, errorDetail.String())
+					} else {
+						diagnostics.AddError("PingFederate validation error "+httpResp.Status, errorDetail.String())
+					}
+				}
+			} else {
 				diagnostics.AddError(errorSummary, err.Error()+" - Detail: "+string(body))
-				httpErrorPrinted = true
 			}
+			httpErrorPrinted = true
 		}
 	}
 	if !httpErrorPrinted {
 		if internalError != nil {
-			tflog.Warn(ctx, "Failed to unmarshal HTTP response body: "+internalError.Error())
+			tflog.Warn(ctx, "Failed to read HTTP response body: "+internalError.Error())
 		}
 		diagnostics.AddError(errorSummary, err.Error())
 	}

--- a/internal/resource/config/utils.go
+++ b/internal/resource/config/utils.go
@@ -134,6 +134,7 @@ func ReportHttpErrorCustomId(ctx context.Context, diagnostics *diag.Diagnostics,
 				for _, validationError := range pfError.ValidationErrors {
 					var errorDetail strings.Builder
 					errorDetail.WriteString(validationError.Message)
+					errorDetail.WriteString("\nHTTP status: " + httpResp.Status)
 					if validationError.FieldPath != "" {
 						errorDetail.WriteString("\nPingFederate field path: ")
 						errorDetail.WriteString(validationError.FieldPath)
@@ -162,9 +163,9 @@ func ReportHttpErrorCustomId(ctx context.Context, diagnostics *diag.Diagnostics,
 								fieldPath = fieldPath.AtMapKey(step)
 							}
 						}
-						diagnostics.AddAttributeError(fieldPath, "PingFederate validation error "+httpResp.Status, errorDetail.String())
+						diagnostics.AddAttributeError(fieldPath, "PingFederate validation error", errorDetail.String())
 					} else {
-						diagnostics.AddError("PingFederate validation error "+httpResp.Status, errorDetail.String())
+						diagnostics.AddError("PingFederate validation error", errorDetail.String())
 					}
 				}
 			} else {


### PR DESCRIPTION
Each individual validation error message will now be split into its own error diagnostic.

Example error message after these changes:
```
╷
│ Error: PingFederate validation error
│
│   with pingfederate_idp_adapter.idpAdapterExample,
│   on resource.tf line 25, in resource "pingfederate_idp_adapter" "idpAdapterExample":
│   25:   adapter_id = "HTMLFormPD"
│
│ Message: The plugin ID is already defined, specify a unique ID.
│ HTTP status: 422 Unprocessable Entity
│ PingFederate field path: id
│ Error ID: plugin_id_in_use
```