### PR TITLE
Latest PF patch support

### DIFF
--- a/.github/workflows/scheduled-acctests.yaml
+++ b/.github/workflows/scheduled-acctests.yaml
@@ -21,8 +21,8 @@ jobs:
           - "11.2.7"
           - "11.3.1"
           - "11.3.7"
-          - "12.0.3"
-          - "12.1.0"
+          - "12.0.5"
+          - "12.1.3"
       max-parallel: 1
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Enhancements
 * Added new `configuration.sensitive_fields` and `configuration.tables.#.rows.#.sensitive_fields` attributes to plugin configuration across the provider. Use these fields when specifying sensitive fields in plugin configuration, such as secrets and passwords. Values specified in these sets will be marked as Sensitive to Terraform and hidden in the CLI and UI output. ([#383]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/383)))
+* Added support for PingFederate patches through `11.2.10`, `11.3.8`, `12.0.5`, `12.1.3`. ([#406]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/406)))
 
 # v0.16.0 September 12, 2024
 ### Resources

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,9 @@ vet:
 	go vet ./...
 
 define productversiondir
- 	PRODUCT_VERSION_DIR=$$(echo "$${PINGFEDERATE_PROVIDER_PRODUCT_VERSION:-12.1.0}" | cut -b 1-4)
+ 	PRODUCT_VERSION_DIR=$$(echo "$${PINGFEDERATE_PROVIDER_PRODUCT_VERSION:-12.1.3}" | cut -b 1-4)
 endef
 
-#TODO: replace `edge` with `latest` here once a sprint release is available for PF 12.1
 starttestcontainer:
 	$(call productversiondir) && docker run --name pingfederate_terraform_provider_container \
 		-d -p 9031:9031 \
@@ -32,7 +31,7 @@ starttestcontainer:
 		-e "OPERATIONAL_MODE=${OPERATIONAL_MODE}" \
 		-v $$(pwd)/server-profiles/shared-profile:/opt/in \
 		-v $$(pwd)/server-profiles/$${PRODUCT_VERSION_DIR}/data.json.subst:/opt/in/instance/bulk-config/data.json.subst \
-		pingidentity/pingfederate:$${PINGFEDERATE_PROVIDER_PRODUCT_VERSION:-12.1.0}-edge
+		pingidentity/pingfederate:$${PINGFEDERATE_PROVIDER_PRODUCT_VERSION:-12.1.3}-latest
 # Wait for the instance to become ready
 	sleep 1
 	duration=0

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -20,7 +20,7 @@ version: "2.19.1"
 
 services:
   pingfederate:
-    image: pingidentity/pingfederate:12.1.0-latest
+    image: pingidentity/pingfederate:12.1.3-latest
     volumes:
       - ./pingfederate:/opt/in
       - pingfederate-out:/opt/out

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,29 +14,36 @@ type SupportedVersion string
 
 // Supported PingFederate versions
 const (
-	PingFederate1120 SupportedVersion = "11.2.0"
-	PingFederate1121 SupportedVersion = "11.2.1"
-	PingFederate1122 SupportedVersion = "11.2.2"
-	PingFederate1123 SupportedVersion = "11.2.3"
-	PingFederate1124 SupportedVersion = "11.2.4"
-	PingFederate1125 SupportedVersion = "11.2.5"
-	PingFederate1126 SupportedVersion = "11.2.6"
-	PingFederate1127 SupportedVersion = "11.2.7"
-	PingFederate1128 SupportedVersion = "11.2.8"
-	PingFederate1129 SupportedVersion = "11.2.9"
-	PingFederate1130 SupportedVersion = "11.3.0"
-	PingFederate1131 SupportedVersion = "11.3.1"
-	PingFederate1132 SupportedVersion = "11.3.2"
-	PingFederate1133 SupportedVersion = "11.3.3"
-	PingFederate1134 SupportedVersion = "11.3.4"
-	PingFederate1135 SupportedVersion = "11.3.5"
-	PingFederate1136 SupportedVersion = "11.3.6"
-	PingFederate1137 SupportedVersion = "11.3.7"
-	PingFederate1200 SupportedVersion = "12.0.0"
-	PingFederate1201 SupportedVersion = "12.0.1"
-	PingFederate1202 SupportedVersion = "12.0.2"
-	PingFederate1203 SupportedVersion = "12.0.3"
-	PingFederate1210 SupportedVersion = "12.1.0"
+	PingFederate1120  SupportedVersion = "11.2.0"
+	PingFederate1121  SupportedVersion = "11.2.1"
+	PingFederate1122  SupportedVersion = "11.2.2"
+	PingFederate1123  SupportedVersion = "11.2.3"
+	PingFederate1124  SupportedVersion = "11.2.4"
+	PingFederate1125  SupportedVersion = "11.2.5"
+	PingFederate1126  SupportedVersion = "11.2.6"
+	PingFederate1127  SupportedVersion = "11.2.7"
+	PingFederate1128  SupportedVersion = "11.2.8"
+	PingFederate1129  SupportedVersion = "11.2.9"
+	PingFederate11210 SupportedVersion = "11.2.10"
+	PingFederate1130  SupportedVersion = "11.3.0"
+	PingFederate1131  SupportedVersion = "11.3.1"
+	PingFederate1132  SupportedVersion = "11.3.2"
+	PingFederate1133  SupportedVersion = "11.3.3"
+	PingFederate1134  SupportedVersion = "11.3.4"
+	PingFederate1135  SupportedVersion = "11.3.5"
+	PingFederate1136  SupportedVersion = "11.3.6"
+	PingFederate1137  SupportedVersion = "11.3.7"
+	PingFederate1138  SupportedVersion = "11.3.8"
+	PingFederate1200  SupportedVersion = "12.0.0"
+	PingFederate1201  SupportedVersion = "12.0.1"
+	PingFederate1202  SupportedVersion = "12.0.2"
+	PingFederate1203  SupportedVersion = "12.0.3"
+	PingFederate1204  SupportedVersion = "12.0.4"
+	PingFederate1205  SupportedVersion = "12.0.5"
+	PingFederate1210  SupportedVersion = "12.1.0"
+	PingFederate1211  SupportedVersion = "12.1.1"
+	PingFederate1212  SupportedVersion = "12.1.2"
+	PingFederate1213  SupportedVersion = "12.1.3"
 )
 
 func IsValid(versionString string) bool {
@@ -64,6 +71,7 @@ func getSortedVersions() []SupportedVersion {
 		PingFederate1127,
 		PingFederate1128,
 		PingFederate1129,
+		PingFederate11210,
 		PingFederate1130,
 		PingFederate1131,
 		PingFederate1132,
@@ -72,11 +80,17 @@ func getSortedVersions() []SupportedVersion {
 		PingFederate1135,
 		PingFederate1136,
 		PingFederate1137,
+		PingFederate1138,
 		PingFederate1200,
 		PingFederate1201,
 		PingFederate1202,
 		PingFederate1203,
+		PingFederate1204,
+		PingFederate1205,
 		PingFederate1210,
+		PingFederate1211,
+		PingFederate1212,
+		PingFederate1213,
 	}
 }
 


### PR DESCRIPTION
No admin API changes in these patches.
Support for
- 11.2.10
- 11.3.8
- 12.0.4
- 12.0.5
- 12.1.1
- 12.1.2
- 12.1.3