### PR TITLE
Handle issuance criteria empty error result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.1 (Unreleased)
+### Bug fixes
+* Fixed inconsistent result errors when `error_result` is set to `null` within `issuance_criteria` attributes. ([#452]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/452)))
+
 # v1.4.0 January 22, 2024
 ### Breaking changes
 * `sp_idp_connection` resource

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_saml_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_saml_test.go
@@ -182,14 +182,14 @@ resource "pingfederate_idp_sp_connection" "example" {
     ]
     issuance_criteria = {
       conditional_criteria = [
-            {
-              attribute_name = "cn"
-              condition      = "MULTIVALUE_CONTAINS_DN"
-              source = {
-                type = "MAPPED_ATTRIBUTES"
-              }
-              value = "cn=Example,dc=example,dc=com"
-            },
+        {
+          attribute_name = "cn"
+          condition      = "MULTIVALUE_CONTAINS_DN"
+          source = {
+            type = "MAPPED_ATTRIBUTES"
+          }
+          value = "cn=Example,dc=example,dc=com"
+        },
       ]
       expression_criteria = null
     }
@@ -331,7 +331,7 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "QGxlec5CX693lBQL"
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "SAML_SUBJECT"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -341,7 +341,7 @@ resource "pingfederate_idp_sp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_saml_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_saml_test.go
@@ -182,6 +182,14 @@ resource "pingfederate_idp_sp_connection" "example" {
     ]
     issuance_criteria = {
       conditional_criteria = [
+            {
+              attribute_name = "cn"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
       ]
       expression_criteria = null
     }
@@ -323,8 +331,17 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "QGxlec5CX693lBQL"
         }
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "SAML_SUBJECT"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_fed_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_fed_test.go
@@ -210,7 +210,7 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "OTIdPJava"
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "SAML_SUBJECT"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -220,7 +220,7 @@ resource "pingfederate_idp_sp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
         restrict_virtual_entity_ids   = false

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_fed_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_fed_test.go
@@ -210,8 +210,17 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "OTIdPJava"
         }
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "SAML_SUBJECT"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
         restrict_virtual_entity_ids   = false

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_trust_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_trust_test.go
@@ -236,8 +236,16 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "UsernameTokenProcessor"
         }
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "TOKEN_SUBJECT"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
         restricted_virtual_entity_ids = []

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_trust_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_ws_trust_test.go
@@ -236,7 +236,7 @@ resource "pingfederate_idp_sp_connection" "example" {
           id = "UsernameTokenProcessor"
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "TOKEN_SUBJECT"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -245,7 +245,7 @@ resource "pingfederate_idp_sp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
         restricted_virtual_entity_ids = []

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oauth_grant_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oauth_grant_test.go
@@ -190,7 +190,7 @@ resource "pingfederate_sp_idp_connection" "example" {
           },
         ]
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "Username"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -200,7 +200,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
       },

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oauth_grant_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oauth_grant_test.go
@@ -190,8 +190,17 @@ resource "pingfederate_sp_idp_connection" "example" {
           },
         ]
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "Username"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
       },

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
@@ -259,7 +259,16 @@ resource "pingfederate_sp_idp_connection" "example" {
           }
         }
         issuance_criteria = {
-          conditional_criteria = []
+      conditional_criteria = [
+            {
+              attribute_name = "subject"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []
@@ -388,8 +397,17 @@ resource "pingfederate_sp_idp_connection" "example" {
           id = pingfederate_authentication_policy_contract.apc1.id
         }
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "email"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
         restrict_virtual_server_ids   = false
@@ -527,8 +545,17 @@ resource "pingfederate_sp_idp_connection" "example" {
           },
         ]
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "OrgName"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
         access_token_manager_ref = {

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
@@ -259,7 +259,7 @@ resource "pingfederate_sp_idp_connection" "example" {
           }
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "subject"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -268,7 +268,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []
@@ -397,7 +397,7 @@ resource "pingfederate_sp_idp_connection" "example" {
           id = pingfederate_authentication_policy_contract.apc1.id
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "email"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -407,7 +407,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
         restrict_virtual_server_ids   = false
@@ -545,7 +545,7 @@ resource "pingfederate_sp_idp_connection" "example" {
           },
         ]
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "OrgName"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -555,7 +555,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
         access_token_manager_ref = {

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
@@ -296,7 +296,7 @@ resource "pingfederate_sp_idp_connection" "example" {
           }
         }
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "subject"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -306,7 +306,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []
@@ -601,17 +601,17 @@ resource "pingfederate_sp_idp_connection" "example" {
         },
       ]
       issuance_criteria = {
-      conditional_criteria = [
-            {
-              attribute_name = "USER_NAME"
-              condition      = "MULTIVALUE_CONTAINS_DN"
-              error_result   = "myerrorresult"
-              source = {
-                type = "MAPPED_ATTRIBUTES"
-              }
-              value = "cn=Example,dc=example,dc=com"
-            },
-      ]
+        conditional_criteria = [
+          {
+            attribute_name = "USER_NAME"
+            condition      = "MULTIVALUE_CONTAINS_DN"
+            error_result   = "myerrorresult"
+            source = {
+              type = "MAPPED_ATTRIBUTES"
+            }
+            value = "cn=Example,dc=example,dc=com"
+          },
+        ]
         expression_criteria = null
       }
     }

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
@@ -296,7 +296,17 @@ resource "pingfederate_sp_idp_connection" "example" {
           }
         }
         issuance_criteria = {
-          conditional_criteria = []
+      conditional_criteria = [
+            {
+              attribute_name = "subject"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
         }
         restrict_virtual_entity_ids   = false
         restricted_virtual_entity_ids = []
@@ -591,8 +601,17 @@ resource "pingfederate_sp_idp_connection" "example" {
         },
       ]
       issuance_criteria = {
-        conditional_criteria = [
-        ]
+      conditional_criteria = [
+            {
+              attribute_name = "USER_NAME"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
         expression_criteria = null
       }
     }

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_fed_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_fed_test.go
@@ -754,7 +754,7 @@ resource "pingfederate_sp_idp_connection" "example" {
         }
         attribute_sources = []
         issuance_criteria = {
-      conditional_criteria = [
+          conditional_criteria = [
             {
               attribute_name = "Username"
               condition      = "MULTIVALUE_CONTAINS_DN"
@@ -763,7 +763,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               value = "cn=Example,dc=example,dc=com"
             },
-      ]
+          ]
           expression_criteria = null
         }
         access_token_manager_ref = {

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_fed_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_fed_test.go
@@ -556,7 +556,6 @@ resource "pingfederate_sp_idp_connection" "example" {
             {
               attribute_name = "SAML_SUBJECT"
               condition      = "EQUALS"
-              error_result   = "error"
               source = {
                 id   = null
                 type = "ASSERTION"
@@ -755,8 +754,16 @@ resource "pingfederate_sp_idp_connection" "example" {
         }
         attribute_sources = []
         issuance_criteria = {
-          conditional_criteria = [
-          ]
+      conditional_criteria = [
+            {
+              attribute_name = "Username"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+      ]
           expression_criteria = null
         }
         access_token_manager_ref = {

--- a/internal/resource/common/issuancecriteria/issuance_criteria_state.go
+++ b/internal/resource/common/issuancecriteria/issuance_criteria_state.go
@@ -45,5 +45,66 @@ func AttrTypes() map[string]attr.Type {
 }
 
 func ToState(con context.Context, issuanceCriteriaFromClient *client.IssuanceCriteria) (types.Object, diag.Diagnostics) {
-	return types.ObjectValueFrom(con, AttrTypes(), issuanceCriteriaFromClient)
+	var respDiags, diags diag.Diagnostics
+	var issuanceCriteriaValue types.Object
+	if issuanceCriteriaFromClient == nil {
+		issuanceCriteriaValue = types.ObjectNull(AttrTypes())
+	} else {
+		var conditionalCriteriaFinalValue types.Set
+		if issuanceCriteriaFromClient.ConditionalCriteria == nil {
+			conditionalCriteriaFinalValue = types.SetNull(ConditionalCriteriaElemType())
+		} else {
+			var conditionalCriteriaValues []attr.Value
+			for _, conditionalCriteriaResponseValue := range issuanceCriteriaFromClient.ConditionalCriteria {
+				conditionalCriteriaSourceValue, diags := types.ObjectValue(sourcetypeidkey.AttrTypes(), map[string]attr.Value{
+					"id":   types.StringPointerValue(conditionalCriteriaResponseValue.Source.Id),
+					"type": types.StringValue(conditionalCriteriaResponseValue.Source.Type),
+				})
+				respDiags.Append(diags...)
+				// PF can return error_result as an empty string rather than null
+				errorResult := conditionalCriteriaResponseValue.ErrorResult
+				if errorResult != nil && *errorResult == "" {
+					errorResult = nil
+				}
+				conditionalCriteriaValue, diags := types.ObjectValue(ConditionalCriteriaElemType().AttrTypes, map[string]attr.Value{
+					"attribute_name": types.StringValue(conditionalCriteriaResponseValue.AttributeName),
+					"condition":      types.StringValue(conditionalCriteriaResponseValue.Condition),
+					"error_result":   types.StringPointerValue(errorResult),
+					"source":         conditionalCriteriaSourceValue,
+					"value":          types.StringValue(conditionalCriteriaResponseValue.Value),
+				})
+				respDiags.Append(diags...)
+				conditionalCriteriaValues = append(conditionalCriteriaValues, conditionalCriteriaValue)
+			}
+			conditionalCriteriaFinalValue, diags = types.SetValue(ConditionalCriteriaElemType(), conditionalCriteriaValues)
+			respDiags.Append(diags...)
+		}
+		var expressionCriteriaFinalValue types.Set
+		if issuanceCriteriaFromClient.ExpressionCriteria == nil {
+			expressionCriteriaFinalValue = types.SetNull(ExpressionCriteriaElemType())
+		} else {
+			var expressionCriteriaValues []attr.Value
+			for _, expressionCriteriaResponseValue := range issuanceCriteriaFromClient.ExpressionCriteria {
+				// PF can return error_result as an empty string rather than null
+				errorResult := expressionCriteriaResponseValue.ErrorResult
+				if errorResult != nil && *errorResult == "" {
+					errorResult = nil
+				}
+				expressionCriteriaValue, diags := types.ObjectValue(ExpressionCriteriaElemType().AttrTypes, map[string]attr.Value{
+					"error_result": types.StringPointerValue(errorResult),
+					"expression":   types.StringValue(expressionCriteriaResponseValue.Expression),
+				})
+				respDiags.Append(diags...)
+				expressionCriteriaValues = append(expressionCriteriaValues, expressionCriteriaValue)
+			}
+			expressionCriteriaFinalValue, diags = types.SetValue(ExpressionCriteriaElemType(), expressionCriteriaValues)
+			respDiags.Append(diags...)
+		}
+		issuanceCriteriaValue, diags = types.ObjectValue(AttrTypes(), map[string]attr.Value{
+			"conditional_criteria": conditionalCriteriaFinalValue,
+			"expression_criteria":  expressionCriteriaFinalValue,
+		})
+		respDiags.Append(diags...)
+	}
+	return issuanceCriteriaValue, respDiags
 }


### PR DESCRIPTION
- Fix inconsistent result errors due to PF returning `error_result` as an empty string within issuance_criteria rather than returning it as null