### PR TITLE
Fix failure in attribute_contract_fulfillment validation when using variable value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Marked the `default_captcha_provider_ref` field as optional in the `pingfederate_captcha_provider_settings` resource, to allow setting the ref to null when no captcha providers are defined ([#464](https://github.com/pingidentity/terraform-provider-pingfederate/pull/464))
 * Marked the `default_notification_publisher_ref` field as optional in the `pingfederate_notification_publisher_settings` resource, to allow setting the ref to null when no notification publishers are defined ([#464](https://github.com/pingidentity/terraform-provider-pingfederate/pull/464))
 * Marked the `default_access_token_manager_ref` field as optional in the `pingfederate_oauth_access_token_manager_settings` resource, to allow setting the ref to null when no access token managers are defined ([#464](https://github.com/pingidentity/terraform-provider-pingfederate/pull/464))
+* Fixed an issue in config validation for `pingfederate_openid_connect_policy` that reported an invalid attribute configuration when using a variable value in `attribute_contract_fulfillment` ([#473](https://github.com/pingidentity/terraform-provider-pingfederate/pull/473))
 
 # v1.4.2 February 5, 2025
 ### Bug fixes

--- a/internal/resource/configvalidators/attribute_contract_fulfillment_validator.go
+++ b/internal/resource/configvalidators/attribute_contract_fulfillment_validator.go
@@ -48,13 +48,13 @@ func (v attributeContractFulfillmentValidator) ValidateMap(ctx context.Context, 
 			continue
 		}
 		sourceTypeAsString, ok := sourceType.(types.String)
-		if !ok {
+		if !ok || sourceTypeAsString.IsUnknown() {
 			continue
 		}
 
 		// Get the value
 		valueAsString, ok := attrAsObject.Attributes()["value"].(types.String)
-		if !ok {
+		if !ok || valueAsString.IsUnknown() {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (v attributeContractFulfillmentValidator) ValidateMap(ctx context.Context, 
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				providererror.InvalidAttributeConfiguration,
-				"When attribute_contract_fulfillment source type is set anything other than 'NO_MAPPING', the value must be defined. "+
+				"When attribute_contract_fulfillment source type is set to anything other than 'NO_MAPPING', the value must be defined. "+
 					fmt.Sprintf("attribute_contract_fulfillment key '%s' has no value defined while using a source type of '%s'", key, sourceTypeAsString.ValueString()),
 			)
 		}


### PR DESCRIPTION
Fixes an "Invalid attribute configuration" error that could occur when using a variable within `attribute_contract_fulfillment`, similar to: 
```
attribute_mapping = {
		attribute_contract_fulfillment = {
			"sub" = {
				source = {
		  			type = "TOKEN"
				}
				value = var.myVariable
			}
		}
  }
```