### PR TITLE
Don't set empty string default for custom attribute source filter fields values in pingfederate_authentication_policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.4.4 (Unreleased)
 ### Bug fixes
-* Updated the `pingfederate_authentication_policies` resource to set no default for custom attribute source `filter_fields.value` attributes, and to validate that the configured filter field value string has length at least 1. This will prevent inconsistent result errors when using custom attribute sources in the authentication policies. Related to a known terraform-plugin-framework bug with defaults in nested sets: [#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867). ([#483](https://github.com/pingidentity/terraform-provider-pingfederate/pull/483))
+* Updated the `pingfederate_authentication_policies` resource to set no default for custom attribute source `filter_fields.value` attributes, and to validate that the configured filter field value string has length at least 1. This will prevent inconsistent result errors when using custom attribute sources in the authentication policies. Related to a known terraform-plugin-framework bug with defaults in nested sets: [#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867). ([#484](https://github.com/pingidentity/terraform-provider-pingfederate/pull/484))
 
 ### Notes
 * bump Go 1.23.5 => 1.24.1 ([#478](https://github.com/pingidentity/terraform-provider-pingfederate/pull/478))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v1.4.4 (Unreleased)
+### Bug fixes
+* Updated the `pingfederate_authentication_policies` resource to set no default for custom attribute source `filter_fields.value` attributes, and to validate that the configured filter field value string has length at least 1. This will prevent inconsistent result errors when using custom attribute sources in the authentication policies. Related to a known terraform-plugin-framework bug with defaults in nested sets: [#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867). ([#483](https://github.com/pingidentity/terraform-provider-pingfederate/pull/483))
+
 ### Notes
 * bump Go 1.23.5 => 1.24.1 ([#478](https://github.com/pingidentity/terraform-provider-pingfederate/pull/478))
 

--- a/Makefile
+++ b/Makefile
@@ -63,18 +63,18 @@ endef
 
 # Set ACC_TEST_NAME to name of test in cli
 testoneacc:
-	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/... -timeout 10m -run ${ACC_TEST_NAME} -v -count=1
+	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/... -timeout 20m -run ${ACC_TEST_NAME} -v -count=1
 
 testaccfolder:
-	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/config/${ACC_TEST_FOLDER}... -timeout 10m -v -count=1
+	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/config/${ACC_TEST_FOLDER}... -timeout 20m -v -count=1
 
 testoneacccomplete: spincontainer testoneacc
 
 # Some tests can step on each other's toes so run those tests in single threaded mode. Run the rest in parallel
 testacc:
-	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test `go list ./internal/acctest/config... | grep -v -e authenticationapi -e oauth/authserversettings -e oauth/openidconnect/policy -e oauth/openidconnect/settings -e oauth/clientsettings -e serversettings/wstruststssettings -e sp/targeturlmappings -e serversettings/systemkeys/rotate -e oauth/cibaserverpolicy/requestpolicies -e notificationpublishers/settings -e oauth/accesstokenmanagers/settings -e oauth/accesstokenmapping -e captchaproviders/settings` -timeout 10m -v -p 4; \
+	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test `go list ./internal/acctest/config... | grep -v -e authenticationapi -e oauth/authserversettings -e oauth/openidconnect/policy -e oauth/openidconnect/settings -e oauth/clientsettings -e serversettings/wstruststssettings -e sp/targeturlmappings -e serversettings/systemkeys/rotate -e oauth/cibaserverpolicy/requestpolicies -e notificationpublishers/settings -e oauth/accesstokenmanagers/settings -e oauth/accesstokenmapping -e captchaproviders/settings` -timeout 20m -v -p 4; \
 	firstTestResult=$$?; \
-	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test `go list ./internal/acctest/config... | grep -e authenticationapi -e oauth/authserversettings -e oauth/openidconnect/policy -e oauth/openidconnect/settings -e oauth/clientsettings -e serversettings/wstruststssettings -e sp/targeturlmappings -e serversettings/systemkeys/rotate -e oauth/cibaserverpolicy/requestpolicies -e notificationpublishers/settings -e oauth/accesstokenmanagers/settings -e oauth/accesstokenmapping -e captchaproviders/settings` -timeout 10m -v -p 1; \
+	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test `go list ./internal/acctest/config... | grep -e authenticationapi -e oauth/authserversettings -e oauth/openidconnect/policy -e oauth/openidconnect/settings -e oauth/clientsettings -e serversettings/wstruststssettings -e sp/targeturlmappings -e serversettings/systemkeys/rotate -e oauth/cibaserverpolicy/requestpolicies -e notificationpublishers/settings -e oauth/accesstokenmanagers/settings -e oauth/accesstokenmapping -e captchaproviders/settings` -timeout 20m -v -p 1; \
 	secondTestResult=$$?; \
 	if test "$$firstTestResult" != "0" || test "$$secondTestResult" != "0"; then \
 		false; \

--- a/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
+++ b/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
@@ -323,23 +323,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                     id = "APIStubs"
                   }
                 },
-                    {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
+                {
+                  ldap_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                    binary_attribute_settings      = null
+                    id                             = "ldapguy"
+                    data_store_ref = {
+                      id = "pingdirectory"
+                    }
+                    description            = "PingDirectory"
+                    member_of_nested_group = false
+                    search_attributes      = ["Subject DN"]
+                    search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                    search_scope           = "SUBTREE"
+                    type                   = "LDAP"
+                  }
+                },
               ],
               attribute_contract_fulfillment = {
                 "subject" = {
@@ -384,20 +384,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
             },
             fragment_mapping = {
               attribute_sources = [
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
+                {
+                  jdbc_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    column_names                   = ["GRANTEE"]
+                    data_store_ref = {
+                      id = "ProvisionerDS"
+                    }
+                    description = "JDBC"
+                    filter      = "subject"
+                    id          = "jdbcguy"
+                    schema      = "INFORMATION_SCHEMA"
+                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                  }
+                },
                 {
                   custom_attribute_source = {
                     data_store_ref = {
@@ -460,23 +460,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                     },
                     fragment_mapping = {
                       attribute_sources = [
-                    {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
+                        {
+                          ldap_attribute_source = {
+                            attribute_contract_fulfillment = null
+                            base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                            binary_attribute_settings      = null
+                            id                             = "ldapguy"
+                            data_store_ref = {
+                              id = "pingdirectory"
+                            }
+                            description            = "PingDirectory"
+                            member_of_nested_group = false
+                            search_attributes      = ["Subject DN"]
+                            search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                            search_scope           = "SUBTREE"
+                            type                   = "LDAP"
+                          }
+                        },
                         {
                           custom_attribute_source = {
                             data_store_ref = {
@@ -550,20 +550,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                                 id = "APIStubs"
                               }
                             },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
+                            {
+                              jdbc_attribute_source = {
+                                attribute_contract_fulfillment = null
+                                column_names                   = ["GRANTEE"]
+                                data_store_ref = {
+                                  id = "ProvisionerDS"
+                                }
+                                description = "JDBC"
+                                filter      = "subject"
+                                id          = "jdbcguy"
+                                schema      = "INFORMATION_SCHEMA"
+                                table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                              }
+                            },
                           ],
                           attribute_contract_fulfillment = {
                             "subject" = {

--- a/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
+++ b/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
@@ -143,37 +143,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 fragment_mapping = {
                   attribute_sources = [
                     {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
-                    {
                       custom_attribute_source = {
                         data_store_ref = {
                           id = "customDataStore"
@@ -234,37 +203,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 }
                 fragment_mapping = {
                   attribute_sources = [
-                    {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
                     {
                       custom_attribute_source = {
                         data_store_ref = {
@@ -334,37 +272,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
             fragment_mapping = {
               attribute_sources = [
                 {
-                  ldap_attribute_source = {
-                    attribute_contract_fulfillment = null
-                    base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                    binary_attribute_settings      = null
-                    id                             = "ldapguy"
-                    data_store_ref = {
-                      id = "pingdirectory"
-                    }
-                    description            = "PingDirectory"
-                    member_of_nested_group = false
-                    search_attributes      = ["Subject DN"]
-                    search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                    search_scope           = "SUBTREE"
-                    type                   = "LDAP"
-                  }
-                },
-                {
-                  jdbc_attribute_source = {
-                    attribute_contract_fulfillment = null
-                    column_names                   = ["GRANTEE"]
-                    data_store_ref = {
-                      id = "ProvisionerDS"
-                    }
-                    description = "JDBC"
-                    filter      = "subject"
-                    id          = "jdbcguy"
-                    schema      = "INFORMATION_SCHEMA"
-                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                  }
-                },
-                {
                   custom_attribute_source = {
                     data_store_ref = {
                       id = "customDataStore"
@@ -430,37 +337,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
             fragment_mapping = {
               attribute_sources = [
                 {
-                  ldap_attribute_source = {
-                    attribute_contract_fulfillment = null
-                    base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                    binary_attribute_settings      = null
-                    id                             = "ldapguy"
-                    data_store_ref = {
-                      id = "pingdirectory"
-                    }
-                    description            = "PingDirectory"
-                    member_of_nested_group = false
-                    search_attributes      = ["Subject DN"]
-                    search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                    search_scope           = "SUBTREE"
-                    type                   = "LDAP"
-                  }
-                },
-                {
-                  jdbc_attribute_source = {
-                    attribute_contract_fulfillment = null
-                    column_names                   = ["GRANTEE"]
-                    data_store_ref = {
-                      id = "ProvisionerDS"
-                    }
-                    description = "JDBC"
-                    filter      = "subject"
-                    id          = "jdbcguy"
-                    schema      = "INFORMATION_SCHEMA"
-                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                  }
-                },
-                {
                   custom_attribute_source = {
                     data_store_ref = {
                       id = "customDataStore"
@@ -523,37 +399,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                     fragment_mapping = {
                       attribute_sources = [
                         {
-                          ldap_attribute_source = {
-                            attribute_contract_fulfillment = null
-                            base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                            binary_attribute_settings      = null
-                            id                             = "ldapguy"
-                            data_store_ref = {
-                              id = "pingdirectory"
-                            }
-                            description            = "PingDirectory"
-                            member_of_nested_group = false
-                            search_attributes      = ["Subject DN"]
-                            search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                            search_scope           = "SUBTREE"
-                            type                   = "LDAP"
-                          }
-                        },
-                        {
-                          jdbc_attribute_source = {
-                            attribute_contract_fulfillment = null
-                            column_names                   = ["GRANTEE"]
-                            data_store_ref = {
-                              id = "ProvisionerDS"
-                            }
-                            description = "JDBC"
-                            filter      = "subject"
-                            id          = "jdbcguy"
-                            schema      = "INFORMATION_SCHEMA"
-                            table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                          }
-                        },
-                        {
                           custom_attribute_source = {
                             data_store_ref = {
                               id = "customDataStore"
@@ -606,37 +451,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                         attribute_mapping = {
                           attribute_sources = [
                             {
-                              ldap_attribute_source = {
-                                attribute_contract_fulfillment = null
-                                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                                binary_attribute_settings      = null
-                                id                             = "ldapguy"
-                                data_store_ref = {
-                                  id = "pingdirectory"
-                                }
-                                description            = "PingDirectory"
-                                member_of_nested_group = false
-                                search_attributes      = ["Subject DN"]
-                                search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                                search_scope           = "SUBTREE"
-                                type                   = "LDAP"
-                              }
-                            },
-                            {
-                              jdbc_attribute_source = {
-                                attribute_contract_fulfillment = null
-                                column_names                   = ["GRANTEE"]
-                                data_store_ref = {
-                                  id = "ProvisionerDS"
-                                }
-                                description = "JDBC"
-                                filter      = "subject"
-                                id          = "jdbcguy"
-                                schema      = "INFORMATION_SCHEMA"
-                                table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                              }
-                            },
-                            {
                               custom_attribute_source = {
                                 data_store_ref = {
                                   id = "customDataStore"
@@ -686,37 +500,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 inbound_mapping = {
                   attribute_sources = [
                     {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
-                    {
                       custom_attribute_source = {
                         data_store_ref = {
                           id = "customDataStore"
@@ -752,37 +535,6 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 },
                 outbound_attribute_mapping = {
                   attribute_sources = [
-                    {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
                     {
                       custom_attribute_source = {
                         data_store_ref = {

--- a/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
+++ b/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
@@ -142,59 +142,59 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 }
                 fragment_mapping = {
                   attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                  ],
                   attribute_contract_fulfillment = {
                     "subject" = {
                       source = {
@@ -234,59 +234,59 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 }
                 fragment_mapping = {
                   attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                  ],
                   attribute_contract_fulfillment = {
                     "subject" = {
                       source = {
@@ -332,60 +332,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
               id = "FirstFactor"
             }
             fragment_mapping = {
-                  attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+              attribute_sources = [
+                {
+                  ldap_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                    binary_attribute_settings      = null
+                    id                             = "ldapguy"
+                    data_store_ref = {
+                      id = "pingdirectory"
+                    }
+                    description            = "PingDirectory"
+                    member_of_nested_group = false
+                    search_attributes      = ["Subject DN"]
+                    search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                    search_scope           = "SUBTREE"
+                    type                   = "LDAP"
+                  }
+                },
+                {
+                  jdbc_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    column_names                   = ["GRANTEE"]
+                    data_store_ref = {
+                      id = "ProvisionerDS"
+                    }
+                    description = "JDBC"
+                    filter      = "subject"
+                    id          = "jdbcguy"
+                    schema      = "INFORMATION_SCHEMA"
+                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                  }
+                },
+                {
+                  custom_attribute_source = {
+                    data_store_ref = {
+                      id = "customDataStore"
+                    }
+                    description = "APIStubs"
+                    filter_fields = [
+                      {
+                        name = "Authorization Header"
+                      },
+                      {
+                        name = "Body"
+                      },
+                      {
+                        name  = "Resource Path"
+                        value = "/users/external"
+                      },
+                    ]
+                    id = "APIStubs"
+                  }
+                },
+              ],
               attribute_contract_fulfillment = {
                 "subject" = {
                   source = {
@@ -428,60 +428,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
               id = "FirstFactor"
             },
             fragment_mapping = {
-                  attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+              attribute_sources = [
+                {
+                  ldap_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                    binary_attribute_settings      = null
+                    id                             = "ldapguy"
+                    data_store_ref = {
+                      id = "pingdirectory"
+                    }
+                    description            = "PingDirectory"
+                    member_of_nested_group = false
+                    search_attributes      = ["Subject DN"]
+                    search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                    search_scope           = "SUBTREE"
+                    type                   = "LDAP"
+                  }
+                },
+                {
+                  jdbc_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    column_names                   = ["GRANTEE"]
+                    data_store_ref = {
+                      id = "ProvisionerDS"
+                    }
+                    description = "JDBC"
+                    filter      = "subject"
+                    id          = "jdbcguy"
+                    schema      = "INFORMATION_SCHEMA"
+                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                  }
+                },
+                {
+                  custom_attribute_source = {
+                    data_store_ref = {
+                      id = "customDataStore"
+                    }
+                    description = "APIStubs"
+                    filter_fields = [
+                      {
+                        name = "Authorization Header"
+                      },
+                      {
+                        name = "Body"
+                      },
+                      {
+                        name  = "Resource Path"
+                        value = "/users/external"
+                      },
+                    ]
+                    id = "APIStubs"
+                  }
+                },
+              ],
               attribute_contract_fulfillment = {
                 "subject" = {
                   source = {
@@ -521,60 +521,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                       id = "FirstFactor"
                     },
                     fragment_mapping = {
-                  attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
+                      attribute_sources = [
+                        {
+                          ldap_attribute_source = {
+                            attribute_contract_fulfillment = null
+                            base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                            binary_attribute_settings      = null
+                            id                             = "ldapguy"
+                            data_store_ref = {
+                              id = "pingdirectory"
+                            }
+                            description            = "PingDirectory"
+                            member_of_nested_group = false
+                            search_attributes      = ["Subject DN"]
+                            search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                            search_scope           = "SUBTREE"
+                            type                   = "LDAP"
+                          }
+                        },
+                        {
+                          jdbc_attribute_source = {
+                            attribute_contract_fulfillment = null
+                            column_names                   = ["GRANTEE"]
+                            data_store_ref = {
+                              id = "ProvisionerDS"
+                            }
+                            description = "JDBC"
+                            filter      = "subject"
+                            id          = "jdbcguy"
+                            schema      = "INFORMATION_SCHEMA"
+                            table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                          }
+                        },
                         {
                           custom_attribute_source = {
                             data_store_ref = {
-                                id = "customDataStore"
+                              id = "customDataStore"
                             }
                             description = "APIStubs"
                             filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
+                              {
+                                name = "Authorization Header"
+                              },
+                              {
+                                name = "Body"
+                              },
+                              {
+                                name  = "Resource Path"
+                                value = "/users/external"
+                              },
                             ]
                             id = "APIStubs"
                           }
                         },
-				  ],
+                      ],
                       attribute_contract_fulfillment = {
                         "subject" = {
                           source = {
@@ -604,60 +604,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                           id = "QGxlec5CX693lBQL"
                         },
                         attribute_mapping = {
-                  attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
+                          attribute_sources = [
+                            {
+                              ldap_attribute_source = {
+                                attribute_contract_fulfillment = null
+                                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                                binary_attribute_settings      = null
+                                id                             = "ldapguy"
+                                data_store_ref = {
+                                  id = "pingdirectory"
+                                }
+                                description            = "PingDirectory"
+                                member_of_nested_group = false
+                                search_attributes      = ["Subject DN"]
+                                search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                                search_scope           = "SUBTREE"
+                                type                   = "LDAP"
+                              }
+                            },
+                            {
+                              jdbc_attribute_source = {
+                                attribute_contract_fulfillment = null
+                                column_names                   = ["GRANTEE"]
+                                data_store_ref = {
+                                  id = "ProvisionerDS"
+                                }
+                                description = "JDBC"
+                                filter      = "subject"
+                                id          = "jdbcguy"
+                                schema      = "INFORMATION_SCHEMA"
+                                table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                              }
+                            },
+                            {
+                              custom_attribute_source = {
+                                data_store_ref = {
+                                  id = "customDataStore"
+                                }
+                                description = "APIStubs"
+                                filter_fields = [
+                                  {
                                     name = "Authorization Header"
-                                },
-                                {
+                                  },
+                                  {
                                     name = "Body"
-                                },
-                                {
+                                  },
+                                  {
                                     name  = "Resource Path"
                                     value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+                                  },
+                                ]
+                                id = "APIStubs"
+                              }
+                            },
+                          ],
                           attribute_contract_fulfillment = {
                             "subject" = {
                               source = {
@@ -685,59 +685,59 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 },
                 inbound_mapping = {
                   attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                  ],
                   attribute_contract_fulfillment = {
                     "pf.local.identity.unique.id" = {
                       source = {
@@ -752,59 +752,59 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 },
                 outbound_attribute_mapping = {
                   attribute_sources = [
-          {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
-              id = "ldapguy"
-              data_store_ref = {
-                id = "pingdirectory"
-              }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
-            }
-          },
-          {
-            jdbc_attribute_source = {
-              attribute_contract_fulfillment = null
-              column_names                   = ["GRANTEE"]
-              data_store_ref = {
-                id = "ProvisionerDS"
-              }
-              description = "JDBC"
-              filter      = "subject"
-              id          = "jdbcguy"
-              schema      = "INFORMATION_SCHEMA"
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-            }
-          },
-                        {
-                          custom_attribute_source = {
-                            data_store_ref = {
-                                id = "customDataStore"
-                            }
-                            description = "APIStubs"
-                            filter_fields = [
-                                {
-                                    name = "Authorization Header"
-                                },
-                                {
-                                    name = "Body"
-                                },
-                                {
-                                    name  = "Resource Path"
-                                    value = "/users/external"
-                                },
-                            ]
-                            id = "APIStubs"
-                          }
-                        },
-				  ],
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                  ],
                   attribute_contract_fulfillment = {
                     "firstName" = {
                       source = {

--- a/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
+++ b/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
@@ -143,6 +143,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 fragment_mapping = {
                   attribute_sources = [
                     {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
                       custom_attribute_source = {
                         data_store_ref = {
                           id = "customDataStore"
@@ -224,6 +241,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                         id = "APIStubs"
                       }
                     },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
                   ],
                   attribute_contract_fulfillment = {
                     "subject" = {
@@ -292,6 +323,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                     id = "APIStubs"
                   }
                 },
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
               ],
               attribute_contract_fulfillment = {
                 "subject" = {
@@ -336,6 +384,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
             },
             fragment_mapping = {
               attribute_sources = [
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
                 {
                   custom_attribute_source = {
                     data_store_ref = {
@@ -398,6 +460,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                     },
                     fragment_mapping = {
                       attribute_sources = [
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
                         {
                           custom_attribute_source = {
                             data_store_ref = {
@@ -471,6 +550,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                                 id = "APIStubs"
                               }
                             },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
                           ],
                           attribute_contract_fulfillment = {
                             "subject" = {
@@ -520,6 +613,23 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                         id = "APIStubs"
                       }
                     },
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
                   ],
                   attribute_contract_fulfillment = {
                     "pf.local.identity.unique.id" = {
@@ -535,6 +645,20 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                 },
                 outbound_attribute_mapping = {
                   attribute_sources = [
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
                     {
                       custom_attribute_source = {
                         data_store_ref = {

--- a/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
+++ b/internal/acctest/config/authenticationpolicies/authentication_policies_test.go
@@ -141,7 +141,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                   id = "InternalAuthN"
                 }
                 fragment_mapping = {
-                  attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                   attribute_contract_fulfillment = {
                     "subject" = {
                       source = {
@@ -180,7 +233,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                   id = "FirstFactor"
                 }
                 fragment_mapping = {
-                  attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                   attribute_contract_fulfillment = {
                     "subject" = {
                       source = {
@@ -226,7 +332,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
               id = "FirstFactor"
             }
             fragment_mapping = {
-              attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
               attribute_contract_fulfillment = {
                 "subject" = {
                   source = {
@@ -269,7 +428,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
               id = "FirstFactor"
             },
             fragment_mapping = {
-              attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
               attribute_contract_fulfillment = {
                 "subject" = {
                   source = {
@@ -309,7 +521,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                       id = "FirstFactor"
                     },
                     fragment_mapping = {
-                      attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                       attribute_contract_fulfillment = {
                         "subject" = {
                           source = {
@@ -339,7 +604,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                           id = "QGxlec5CX693lBQL"
                         },
                         attribute_mapping = {
-                          attribute_sources = []
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                           attribute_contract_fulfillment = {
                             "subject" = {
                               source = {
@@ -366,7 +684,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                   id = "adminIdentityProfile",
                 },
                 inbound_mapping = {
-                  attribute_sources = [],
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                   attribute_contract_fulfillment = {
                     "pf.local.identity.unique.id" = {
                       source = {
@@ -380,7 +751,60 @@ resource "pingfederate_authentication_policies" "%[1]s" {
                   }
                 },
                 outbound_attribute_mapping = {
-                  attribute_sources = [],
+                  attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              id = "ldapguy"
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+          {
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "subject"
+              id          = "jdbcguy"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+          },
+                        {
+                          custom_attribute_source = {
+                            data_store_ref = {
+                                id = "customDataStore"
+                            }
+                            description = "APIStubs"
+                            filter_fields = [
+                                {
+                                    name = "Authorization Header"
+                                },
+                                {
+                                    name = "Body"
+                                },
+                                {
+                                    name  = "Resource Path"
+                                    value = "/users/external"
+                                },
+                            ]
+                            id = "APIStubs"
+                          }
+                        },
+				  ],
                   attribute_contract_fulfillment = {
                     "firstName" = {
                       source = {

--- a/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
+++ b/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
@@ -161,7 +161,43 @@ resource "pingfederate_authentication_policies_fragment" "%[1]s" {
               id = pingfederate_authentication_policy_contract.mycontract.contract_id
             }
             attribute_mapping = {
-              attribute_sources = []
+              attribute_sources = [
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                    {
+                      jdbc_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        column_names                   = ["GRANTEE"]
+                        data_store_ref = {
+                          id = "ProvisionerDS"
+                        }
+                        description = "JDBC"
+                        filter      = "subject"
+                        id          = "jdbcguy"
+                        schema      = "INFORMATION_SCHEMA"
+                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                      }
+                    },
+                  ],
               attribute_contract_fulfillment = {
                 "firstName" : {
                   source = {
@@ -537,7 +573,46 @@ resource "pingfederate_idp_adapter" "myadapter" {
     mask_ognl_values = false
   }
   attribute_mapping = {
-    attribute_sources = []
+    attribute_sources = [
+                    {
+                      ldap_attribute_source = {
+                        attribute_contract_fulfillment = null
+                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                        binary_attribute_settings      = null
+                        id                             = "ldapguy"
+                        data_store_ref = {
+                          id = "pingdirectory"
+                        }
+                        description            = "PingDirectory"
+                        member_of_nested_group = false
+                        search_attributes      = ["Subject DN"]
+                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                        search_scope           = "SUBTREE"
+                        type                   = "LDAP"
+                      }
+                    },
+                    {
+                      custom_attribute_source = {
+                        data_store_ref = {
+                          id = "customDataStore"
+                        }
+                        description = "APIStubs"
+                        filter_fields = [
+                          {
+                            name = "Authorization Header"
+                          },
+                          {
+                            name = "Body"
+                          },
+                          {
+                            name  = "Resource Path"
+                            value = "/users/external"
+                          },
+                        ]
+                        id = "APIStubs"
+                      }
+                    },
+                  ],
     attribute_contract_fulfillment = {
       "country" : {
         source = {

--- a/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
+++ b/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
@@ -162,42 +162,42 @@ resource "pingfederate_authentication_policies_fragment" "%[1]s" {
             }
             attribute_mapping = {
               attribute_sources = [
-                    {
-                      custom_attribute_source = {
-                        data_store_ref = {
-                          id = "customDataStore"
-                        }
-                        description = "APIStubs"
-                        filter_fields = [
-                          {
-                            name = "Authorization Header"
-                          },
-                          {
-                            name = "Body"
-                          },
-                          {
-                            name  = "Resource Path"
-                            value = "/users/external"
-                          },
-                        ]
-                        id = "APIStubs"
-                      }
-                    },
-                    {
-                      jdbc_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        column_names                   = ["GRANTEE"]
-                        data_store_ref = {
-                          id = "ProvisionerDS"
-                        }
-                        description = "JDBC"
-                        filter      = "subject"
-                        id          = "jdbcguy"
-                        schema      = "INFORMATION_SCHEMA"
-                        table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
-                      }
-                    },
-                  ],
+                {
+                  custom_attribute_source = {
+                    data_store_ref = {
+                      id = "customDataStore"
+                    }
+                    description = "APIStubs"
+                    filter_fields = [
+                      {
+                        name = "Authorization Header"
+                      },
+                      {
+                        name = "Body"
+                      },
+                      {
+                        name  = "Resource Path"
+                        value = "/users/external"
+                      },
+                    ]
+                    id = "APIStubs"
+                  }
+                },
+                {
+                  jdbc_attribute_source = {
+                    attribute_contract_fulfillment = null
+                    column_names                   = ["GRANTEE"]
+                    data_store_ref = {
+                      id = "ProvisionerDS"
+                    }
+                    description = "JDBC"
+                    filter      = "subject"
+                    id          = "jdbcguy"
+                    schema      = "INFORMATION_SCHEMA"
+                    table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+                  }
+                },
+              ],
               attribute_contract_fulfillment = {
                 "firstName" : {
                   source = {
@@ -574,45 +574,45 @@ resource "pingfederate_idp_adapter" "myadapter" {
   }
   attribute_mapping = {
     attribute_sources = [
-                    {
-                      ldap_attribute_source = {
-                        attribute_contract_fulfillment = null
-                        base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                        binary_attribute_settings      = null
-                        id                             = "ldapguy"
-                        data_store_ref = {
-                          id = "pingdirectory"
-                        }
-                        description            = "PingDirectory"
-                        member_of_nested_group = false
-                        search_attributes      = ["Subject DN"]
-                        search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                        search_scope           = "SUBTREE"
-                        type                   = "LDAP"
-                      }
-                    },
-                    {
-                      custom_attribute_source = {
-                        data_store_ref = {
-                          id = "customDataStore"
-                        }
-                        description = "APIStubs"
-                        filter_fields = [
-                          {
-                            name = "Authorization Header"
-                          },
-                          {
-                            name = "Body"
-                          },
-                          {
-                            name  = "Resource Path"
-                            value = "/users/external"
-                          },
-                        ]
-                        id = "APIStubs"
-                      }
-                    },
-                  ],
+      {
+        ldap_attribute_source = {
+          attribute_contract_fulfillment = null
+          base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+          binary_attribute_settings      = null
+          id                             = "ldapguy"
+          data_store_ref = {
+            id = "pingdirectory"
+          }
+          description            = "PingDirectory"
+          member_of_nested_group = false
+          search_attributes      = ["Subject DN"]
+          search_filter          = "(&(memberUid=uid)(cn=Postman))"
+          search_scope           = "SUBTREE"
+          type                   = "LDAP"
+        }
+      },
+      {
+        custom_attribute_source = {
+          data_store_ref = {
+            id = "customDataStore"
+          }
+          description = "APIStubs"
+          filter_fields = [
+            {
+              name = "Authorization Header"
+            },
+            {
+              name = "Body"
+            },
+            {
+              name  = "Resource Path"
+              value = "/users/external"
+            },
+          ]
+          id = "APIStubs"
+        }
+      },
+    ],
     attribute_contract_fulfillment = {
       "country" : {
         source = {

--- a/internal/resource/common/attributemapping/attribute_mapping.go
+++ b/internal/resource/common/attributemapping/attribute_mapping.go
@@ -34,10 +34,24 @@ func AttrTypes() map[string]attr.Type {
 }
 
 func ToSchema(required bool) schema.SingleNestedAttribute {
+	return toSchemaInternal(required, true)
+}
+
+func ToSchemaNoValueDefault(required bool) schema.SingleNestedAttribute {
+	return toSchemaInternal(required, false)
+}
+
+func toSchemaInternal(required, includeValueDefault bool) schema.SingleNestedAttribute {
+	var attributeSources schema.Attribute
+	if includeValueDefault {
+		attributeSources = attributesources.ToSchema(0, false)
+	} else {
+		attributeSources = attributesources.ToSchemaNoValueDefault(0, false)
+	}
 	return schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, true),
-			"attribute_sources":              attributesources.ToSchema(0, false),
+			"attribute_sources":              attributeSources,
 			"issuance_criteria":              issuancecriteria.ToSchema(),
 		},
 		Required:    required,

--- a/internal/resource/common/policyaction/policy_action_schema.go
+++ b/internal/resource/common/policyaction/policy_action_schema.go
@@ -25,6 +25,13 @@ func commonPolicyActionSchema() map[string]schema.Attribute {
 	return commonPolicyActionSchema
 }
 
+func attributeSourcesAttr(includeValueDefault bool) schema.Attribute {
+	if includeValueDefault {
+		return attributesources.ToSchema(0, false)
+	}
+	return attributesources.ToSchemaNoValueDefault(0, false)
+}
+
 func commonAttributeRulesAttr() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
@@ -85,12 +92,12 @@ func commonAttributeRulesAttr() schema.Attribute {
 
 // Complete schemas for the individual types of policy action
 
-func apcMappingPolicyActionSchema() schema.SingleNestedAttribute {
+func apcMappingPolicyActionSchema(includeValueDefault bool) schema.SingleNestedAttribute {
 	attrs := commonPolicyActionSchema()
 	attrs["attribute_mapping"] = schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, true),
-			"attribute_sources":              attributesources.ToSchemaNoValueDefault(0, false),
+			"attribute_sources":              attributeSourcesAttr(includeValueDefault),
 			"issuance_criteria":              issuancecriteria.ToSchema(),
 		},
 		Required:    true,
@@ -184,7 +191,7 @@ func donePolicyActionSchema() schema.SingleNestedAttribute {
 	}
 }
 
-func fragmentPolicyActionSchema() schema.SingleNestedAttribute {
+func fragmentPolicyActionSchema(includeValueDefault bool) schema.SingleNestedAttribute {
 	attrs := commonPolicyActionSchema()
 	attrs["attribute_rules"] = commonAttributeRulesAttr()
 	attrs["fragment"] = schema.SingleNestedAttribute{
@@ -211,7 +218,7 @@ func fragmentPolicyActionSchema() schema.SingleNestedAttribute {
 					},
 				},
 			},
-			"attribute_sources": attributesources.ToSchemaNoValueDefault(0, false),
+			"attribute_sources": attributeSourcesAttr(includeValueDefault),
 			"issuance_criteria": issuancecriteria.ToSchema(),
 		},
 		Required:    false,
@@ -225,9 +232,13 @@ func fragmentPolicyActionSchema() schema.SingleNestedAttribute {
 	}
 }
 
-func localIdentityMappingPolicyActionSchema() schema.SingleNestedAttribute {
+func localIdentityMappingPolicyActionSchema(includeValueDefault bool) schema.SingleNestedAttribute {
 	attrs := commonPolicyActionSchema()
-	attrs["inbound_mapping"] = attributemapping.ToSchemaNoValueDefault(false)
+	if includeValueDefault {
+		attrs["inbound_mapping"] = attributemapping.ToSchema(false)
+	} else {
+		attrs["inbound_mapping"] = attributemapping.ToSchemaNoValueDefault(false)
+	}
 	attrs["local_identity_ref"] = schema.SingleNestedAttribute{
 		Attributes:  resourcelink.ToSchema(),
 		Required:    true,
@@ -236,7 +247,7 @@ func localIdentityMappingPolicyActionSchema() schema.SingleNestedAttribute {
 	attrs["outbound_attribute_mapping"] = schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, true),
-			"attribute_sources":              attributesources.ToSchemaNoValueDefault(0, false),
+			"attribute_sources":              attributeSourcesAttr(includeValueDefault),
 			"issuance_criteria":              issuancecriteria.ToSchema(),
 		},
 		Required:    true,
@@ -259,19 +270,27 @@ func restartPolicyActionSchema() schema.SingleNestedAttribute {
 
 // Schema for the polymorphic attribute allowing you to specify a single policy action type
 func ToSchema() schema.SingleNestedAttribute {
+	return toSchemaInternal(true)
+}
+
+func ToSchemaNoValueDefault() schema.SingleNestedAttribute {
+	return toSchemaInternal(false)
+}
+
+func toSchemaInternal(includeValueDefault bool) schema.SingleNestedAttribute {
 	// In the future it may be worth adding validators to ensure only one of the policy action types is set, but
 	// currently it causes a big performance hit
 	return schema.SingleNestedAttribute{
 		Description: "The result action.",
 		Optional:    true,
 		Attributes: map[string]schema.Attribute{
-			"apc_mapping_policy_action":            apcMappingPolicyActionSchema(),
+			"apc_mapping_policy_action":            apcMappingPolicyActionSchema(includeValueDefault),
 			"authn_selector_policy_action":         authnSelectorPolicyActionSchema(),
 			"authn_source_policy_action":           authnSourcePolicyActionSchema(),
 			"continue_policy_action":               continuePolicyActionSchema(),
 			"done_policy_action":                   donePolicyActionSchema(),
-			"fragment_policy_action":               fragmentPolicyActionSchema(),
-			"local_identity_mapping_policy_action": localIdentityMappingPolicyActionSchema(),
+			"fragment_policy_action":               fragmentPolicyActionSchema(includeValueDefault),
+			"local_identity_mapping_policy_action": localIdentityMappingPolicyActionSchema(includeValueDefault),
 			"restart_policy_action":                restartPolicyActionSchema(),
 		},
 	}

--- a/internal/resource/common/policyaction/policy_action_schema.go
+++ b/internal/resource/common/policyaction/policy_action_schema.go
@@ -90,7 +90,7 @@ func apcMappingPolicyActionSchema() schema.SingleNestedAttribute {
 	attrs["attribute_mapping"] = schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, true),
-			"attribute_sources":              attributesources.ToSchema(0, false),
+			"attribute_sources":              attributesources.ToSchemaNoValueDefault(0, false),
 			"issuance_criteria":              issuancecriteria.ToSchema(),
 		},
 		Required:    true,
@@ -211,7 +211,7 @@ func fragmentPolicyActionSchema() schema.SingleNestedAttribute {
 					},
 				},
 			},
-			"attribute_sources": attributesources.ToSchema(0, false),
+			"attribute_sources": attributesources.ToSchemaNoValueDefault(0, false),
 			"issuance_criteria": issuancecriteria.ToSchema(),
 		},
 		Required:    false,
@@ -236,7 +236,7 @@ func localIdentityMappingPolicyActionSchema() schema.SingleNestedAttribute {
 	attrs["outbound_attribute_mapping"] = schema.SingleNestedAttribute{
 		Attributes: map[string]schema.Attribute{
 			"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, true),
-			"attribute_sources":              attributesources.ToSchema(0, false),
+			"attribute_sources":              attributesources.ToSchemaNoValueDefault(0, false),
 			"issuance_criteria":              issuancecriteria.ToSchema(),
 		},
 		Required:    true,

--- a/internal/resource/common/policyaction/policy_action_schema.go
+++ b/internal/resource/common/policyaction/policy_action_schema.go
@@ -227,7 +227,7 @@ func fragmentPolicyActionSchema() schema.SingleNestedAttribute {
 
 func localIdentityMappingPolicyActionSchema() schema.SingleNestedAttribute {
 	attrs := commonPolicyActionSchema()
-	attrs["inbound_mapping"] = attributemapping.ToSchema(false)
+	attrs["inbound_mapping"] = attributemapping.ToSchemaNoValueDefault(false)
 	attrs["local_identity_ref"] = schema.SingleNestedAttribute{
 		Attributes:  resourcelink.ToSchema(),
 		Required:    true,

--- a/internal/resource/config/authenticationpolicies/authentication_policies_resource.go
+++ b/internal/resource/config/authenticationpolicies/authentication_policies_resource.go
@@ -107,7 +107,7 @@ func (r *authenticationPoliciesResource) Schema(ctx context.Context, req resourc
 							Default:     booldefault.StaticBool(true),
 							Description: "Whether or not this authentication policy tree is enabled. Default is true.",
 						},
-						"root_node": authenticationpolicytreenode.ToSchema("A node inside the authentication policy tree."),
+						"root_node": authenticationpolicytreenode.ToSchemaNoValueDefault("A node inside the authentication policy tree."),
 						"handle_failures_locally": schema.BoolAttribute{
 							Optional:    true,
 							Computed:    true,


### PR DESCRIPTION
Fixes inconsistent result errors in pingfederate_authentication_policies when using custom attribute sources. Previously the `filter_fields.value` attribute within custom attribute sources had a default of `""`, which is still the case for other resources using attribute sources. This caused inconsistent result errors because the authentication policies endpoint returns empty strings as null for these attributes. Now there is no longer a default for `filter_fields.value` for this resource, and there is new validation that any user-provided value has length at least 1.