### PR TITLE
Handle certs without a set id in SP and IdP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.4.5 (Unreleased)
 ### Bug fixes
-* Fixed an inconsitent result error that would occur when configuring certificates with no `id` value in the `pingfederate_idp_sp_connection` and `pingfederate_sp_idp_connection` resources. Also fixed a related inconsistent result failure that would occur when modifying the `id` of a certificate.
+* Fixed an inconsistent result error that would occur when configuring certificates with no `id` value in the `pingfederate_idp_sp_connection` and `pingfederate_sp_idp_connection` resources. Also fixed a related inconsistent result failure that would occur when modifying the `id` of a certificate.
 
 # v1.4.4 April 8, 2025
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.5 (Unreleased)
+### Bug fixes
+* Fixed an inconsitent result error that would occur when configuring certificates with no `id` value in the `pingfederate_idp_sp_connection` and `pingfederate_sp_idp_connection` resources. Also fixed a related inconsistent result failure that would occur when modifying the `id` of a certificate.
+
 # v1.4.4 April 8, 2025
 ### Bug fixes
 * Updated the `pingfederate_authentication_policies` resource to set no default for custom attribute source `filter_fields.value` attributes, and to validate that the configured filter field value string has length at least 1. This will prevent inconsistent result errors when using custom attribute sources in the authentication policies. Related to a known terraform-plugin-framework bug with defaults in nested sets: [#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867). ([#484](https://github.com/pingidentity/terraform-provider-pingfederate/pull/484))

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endef
 
 # Set ACC_TEST_NAME to name of test in cli
 testoneacc:
-	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/... -timeout 20m -run ${ACC_TEST_NAME} -v -count=1
+	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/config/${ACC_TEST_FOLDER}... -timeout 20m -run ${ACC_TEST_NAME} -v -count=1
 
 testaccfolder:
 	$(call test_acc_common_env_vars) $(call test_acc_basic_auth_env_vars) TF_ACC=1 go test ./internal/acctest/config/${ACC_TEST_FOLDER}... -timeout 20m -v -count=1

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
@@ -115,7 +115,7 @@ resource "pingfederate_idp_sp_connection" "example" {
 		certs = [
 		{
 			active_verification_cert    = true
-			encryption_cert             = true
+			encryption_cert             = false
 			primary_verification_cert   = true
 			secondary_verification_cert = false
 			x509_file = {

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
@@ -20,7 +20,7 @@ func TestAccIdpSpConnection_CertificateId(t *testing.T) {
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
 		},
-		CheckDestroy: spIdpConnection_SimpleCheckDestroy,
+		CheckDestroy: idpSpConnection_SimpleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Test applying two certs without defined ids in credentials

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
@@ -112,18 +112,18 @@ resource "pingfederate_idp_sp_connection" "example" {
     ]
     key_transport_algorithm = "RSA_OAEP"
     inbound_back_channel_auth = {
-		certs = [
-		{
-			active_verification_cert    = true
-			encryption_cert             = false
-			primary_verification_cert   = true
-			secondary_verification_cert = false
-			x509_file = {
-			file_data = "-----BEGIN CERTIFICATE-----\nMIIDOjCCAiICCQCjbB7XBVkxCzANBgkqhkiG9w0BAQsFADBfMRIwEAYDVQQDDAlsb2NhbGhvc3Qx\nDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsMBFBJTkcxDDAKBgNVBAoM\nA0NEUjELMAkGA1UEBhMCVVMwHhcNMjMwNzE0MDI1NDUzWhcNMjQwNzEzMDI1NDUzWjBfMRIwEAYD\nVQQDDAlsb2NhbGhvc3QxDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsM\nBFBJTkcxDDAKBgNVBAoMA0NEUjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQC5yFrh9VR2wk9IjzMz+Ei80K453g1j1/Gv3EQ/SC9h7HZBI6aV9FaEYhGnaquRT5q8\n7p8lzCphKNXVyeL6T/pDJOW70zXItkl8Ryoc0tIaknRQmj8+YA0Hr9GDdmYev2yrxSoVS7s5Bl8p\noasn3DljgnWT07vsQz+hw3NY4SPp7IFGP2PpGUBBIIvrOaDWpPGsXeznBxSFtis6Qo+JiEoaVql9\nb9/XyKZj65wOsVyZhFWeM1nCQITSP9OqOc9FSoDFYQ1AVogm4A2AzUrkMnT1SrN2dCuTmNbeVw7g\nOMqMrVf0CiTv9hI0cATbO5we1sPAlJxscSkJjsaI+sQfjiAnAgMBAAEwDQYJKoZIhvcNAQELBQAD\nggEBACgwoH1qklPF1nI9+WbIJ4K12Dl9+U3ZMZa2lP4hAk1rMBHk9SHboOU1CHDQKT1Z6uxi0NI4\nJZHmP1qP8KPNEWTI8Q76ue4Q3aiA53EQguzGb3SEtyp36JGBq05Jor9erEebFftVl83NFvio72Fn\n0N2xvu8zCnlylf2hpz9x1i01Xnz5UNtZ2ppsf2zzT+4U6w3frH+pkp0RDPuoe9mnBF001AguP31h\nSBZyZzWcwQltuNELnSRCcgJl4kC2h3mAgaVtYalrFxLRa3tA2XF2BHRHmKgocedVhTq+81xrqj+W\nQuDmUe06DnrS3Ohmyj3jhsCCluznAolmrBhT/SaDuGg=\n-----END CERTIFICATE-----\n"
-			# No id supplied for the cert
-			}
-		},
-		]
+      certs = [
+        {
+          active_verification_cert    = true
+          encryption_cert             = false
+          primary_verification_cert   = true
+          secondary_verification_cert = false
+          x509_file = {
+            file_data = "-----BEGIN CERTIFICATE-----\nMIIDOjCCAiICCQCjbB7XBVkxCzANBgkqhkiG9w0BAQsFADBfMRIwEAYDVQQDDAlsb2NhbGhvc3Qx\nDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsMBFBJTkcxDDAKBgNVBAoM\nA0NEUjELMAkGA1UEBhMCVVMwHhcNMjMwNzE0MDI1NDUzWhcNMjQwNzEzMDI1NDUzWjBfMRIwEAYD\nVQQDDAlsb2NhbGhvc3QxDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsM\nBFBJTkcxDDAKBgNVBAoMA0NEUjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQC5yFrh9VR2wk9IjzMz+Ei80K453g1j1/Gv3EQ/SC9h7HZBI6aV9FaEYhGnaquRT5q8\n7p8lzCphKNXVyeL6T/pDJOW70zXItkl8Ryoc0tIaknRQmj8+YA0Hr9GDdmYev2yrxSoVS7s5Bl8p\noasn3DljgnWT07vsQz+hw3NY4SPp7IFGP2PpGUBBIIvrOaDWpPGsXeznBxSFtis6Qo+JiEoaVql9\nb9/XyKZj65wOsVyZhFWeM1nCQITSP9OqOc9FSoDFYQ1AVogm4A2AzUrkMnT1SrN2dCuTmNbeVw7g\nOMqMrVf0CiTv9hI0cATbO5we1sPAlJxscSkJjsaI+sQfjiAnAgMBAAEwDQYJKoZIhvcNAQELBQAD\nggEBACgwoH1qklPF1nI9+WbIJ4K12Dl9+U3ZMZa2lP4hAk1rMBHk9SHboOU1CHDQKT1Z6uxi0NI4\nJZHmP1qP8KPNEWTI8Q76ue4Q3aiA53EQguzGb3SEtyp36JGBq05Jor9erEebFftVl83NFvio72Fn\n0N2xvu8zCnlylf2hpz9x1i01Xnz5UNtZ2ppsf2zzT+4U6w3frH+pkp0RDPuoe9mnBF001AguP31h\nSBZyZzWcwQltuNELnSRCcgJl4kC2h3mAgaVtYalrFxLRa3tA2XF2BHRHmKgocedVhTq+81xrqj+W\nQuDmUe06DnrS3Ohmyj3jhsCCluznAolmrBhT/SaDuGg=\n-----END CERTIFICATE-----\n"
+            # No id supplied for the cert
+          }
+        },
+      ]
       digital_signature = false
       http_basic_credentials = {
         encrypted_password = "OBF:JWE:eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2Iiwia2lkIjoiUWVzOVR5eTV5WiIsInZlcnNpb24iOiIxMi4xLjMuMCJ9..Q7cuD9L9LT5W8VKdl32iOQ.4AqqdVvegqo6vQxJBc1sBZckQgjxaCrSssbiCaQV3B_ijayEtLePXRCtLUE8P9-U8526lbVee7t93rrByvapYw.PgMT-r6-kKm8TJrmP7-MHg"

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_cert_id_test.go
@@ -1,0 +1,285 @@
+// Copyright © 2025 Ping Identity Corporation
+
+package idpspconnection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/provider"
+)
+
+func TestAccIdpSpConnection_CertificateId(t *testing.T) {
+	connId := "certidconn"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: spIdpConnection_SimpleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Test applying two certs without defined ids in credentials
+				Config: idpSpConnection_CredentialsCertNoId(connId),
+			},
+		},
+	})
+}
+
+func idpSpConnection_CredentialsCertNoId(id string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "pingfederate_idp_sp_connection" "example" {
+  active               = false
+  application_icon_url = "https://example.com/icon.png"
+  application_name     = "MyApp"
+  attribute_query = {
+    attributes = ["cn"]
+    attribute_contract_fulfillment = {
+      "cn" = {
+        source = {
+          type = "TEXT"
+        }
+        value = "subject"
+      }
+    }
+    attribute_sources = [
+      {
+        custom_attribute_source = null
+        jdbc_attribute_source = {
+          attribute_contract_fulfillment = null
+          column_names                   = ["GRANTEE"]
+          data_store_ref = {
+            id = "ProvisionerDS"
+          }
+          description = "JDBC"
+          filter      = "example"
+          id          = "jdbcattrsource"
+          schema      = "INFORMATION_SCHEMA"
+          table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+        }
+        ldap_attribute_source = null
+      },
+    ]
+    issuance_criteria = {
+      conditional_criteria = [
+        {
+          attribute_name = "cn"
+          condition      = "MULTIVALUE_CONTAINS_DN"
+          source = {
+            type = "MAPPED_ATTRIBUTES"
+          }
+          value = "cn=Example,dc=example,dc=com"
+        },
+      ]
+      expression_criteria = null
+    }
+    policy = {
+      encrypt_assertion              = false
+      require_encrypted_name_id      = false
+      require_signed_attribute_query = false
+      sign_assertion                 = false
+      sign_response                  = false
+    }
+  }
+  base_url               = "https://example.com"
+  connection_id          = "%s"
+  connection_target_type = "STANDARD"
+  contact_info = {
+    company    = "Example Corp"
+    first_name = "Bugs"
+    phone      = "5555555"
+    email      = "bugsbunny@example.com"
+  }
+  credentials = {
+    block_encryption_algorithm = "AES_128"
+    certs = [
+      {
+        active_verification_cert    = true
+        encryption_cert             = true
+        primary_verification_cert   = true
+        secondary_verification_cert = false
+        x509_file = {
+          file_data = "-----BEGIN CERTIFICATE-----\nMIIDOjCCAiICCQCjbB7XBVkxCzANBgkqhkiG9w0BAQsFADBfMRIwEAYDVQQDDAlsb2NhbGhvc3Qx\nDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsMBFBJTkcxDDAKBgNVBAoM\nA0NEUjELMAkGA1UEBhMCVVMwHhcNMjMwNzE0MDI1NDUzWhcNMjQwNzEzMDI1NDUzWjBfMRIwEAYD\nVQQDDAlsb2NhbGhvc3QxDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsM\nBFBJTkcxDDAKBgNVBAoMA0NEUjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQC5yFrh9VR2wk9IjzMz+Ei80K453g1j1/Gv3EQ/SC9h7HZBI6aV9FaEYhGnaquRT5q8\n7p8lzCphKNXVyeL6T/pDJOW70zXItkl8Ryoc0tIaknRQmj8+YA0Hr9GDdmYev2yrxSoVS7s5Bl8p\noasn3DljgnWT07vsQz+hw3NY4SPp7IFGP2PpGUBBIIvrOaDWpPGsXeznBxSFtis6Qo+JiEoaVql9\nb9/XyKZj65wOsVyZhFWeM1nCQITSP9OqOc9FSoDFYQ1AVogm4A2AzUrkMnT1SrN2dCuTmNbeVw7g\nOMqMrVf0CiTv9hI0cATbO5we1sPAlJxscSkJjsaI+sQfjiAnAgMBAAEwDQYJKoZIhvcNAQELBQAD\nggEBACgwoH1qklPF1nI9+WbIJ4K12Dl9+U3ZMZa2lP4hAk1rMBHk9SHboOU1CHDQKT1Z6uxi0NI4\nJZHmP1qP8KPNEWTI8Q76ue4Q3aiA53EQguzGb3SEtyp36JGBq05Jor9erEebFftVl83NFvio72Fn\n0N2xvu8zCnlylf2hpz9x1i01Xnz5UNtZ2ppsf2zzT+4U6w3frH+pkp0RDPuoe9mnBF001AguP31h\nSBZyZzWcwQltuNELnSRCcgJl4kC2h3mAgaVtYalrFxLRa3tA2XF2BHRHmKgocedVhTq+81xrqj+W\nQuDmUe06DnrS3Ohmyj3jhsCCluznAolmrBhT/SaDuGg=\n-----END CERTIFICATE-----\n"
+          # No id supplied for the cert
+        }
+      },
+    ]
+    key_transport_algorithm = "RSA_OAEP"
+    inbound_back_channel_auth = {
+		certs = [
+		{
+			active_verification_cert    = true
+			encryption_cert             = true
+			primary_verification_cert   = true
+			secondary_verification_cert = false
+			x509_file = {
+			file_data = "-----BEGIN CERTIFICATE-----\nMIIDOjCCAiICCQCjbB7XBVkxCzANBgkqhkiG9w0BAQsFADBfMRIwEAYDVQQDDAlsb2NhbGhvc3Qx\nDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsMBFBJTkcxDDAKBgNVBAoM\nA0NEUjELMAkGA1UEBhMCVVMwHhcNMjMwNzE0MDI1NDUzWhcNMjQwNzEzMDI1NDUzWjBfMRIwEAYD\nVQQDDAlsb2NhbGhvc3QxDjAMBgNVBAgMBVRFWEFTMQ8wDQYDVQQHDAZBVVNUSU4xDTALBgNVBAsM\nBFBJTkcxDDAKBgNVBAoMA0NEUjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQC5yFrh9VR2wk9IjzMz+Ei80K453g1j1/Gv3EQ/SC9h7HZBI6aV9FaEYhGnaquRT5q8\n7p8lzCphKNXVyeL6T/pDJOW70zXItkl8Ryoc0tIaknRQmj8+YA0Hr9GDdmYev2yrxSoVS7s5Bl8p\noasn3DljgnWT07vsQz+hw3NY4SPp7IFGP2PpGUBBIIvrOaDWpPGsXeznBxSFtis6Qo+JiEoaVql9\nb9/XyKZj65wOsVyZhFWeM1nCQITSP9OqOc9FSoDFYQ1AVogm4A2AzUrkMnT1SrN2dCuTmNbeVw7g\nOMqMrVf0CiTv9hI0cATbO5we1sPAlJxscSkJjsaI+sQfjiAnAgMBAAEwDQYJKoZIhvcNAQELBQAD\nggEBACgwoH1qklPF1nI9+WbIJ4K12Dl9+U3ZMZa2lP4hAk1rMBHk9SHboOU1CHDQKT1Z6uxi0NI4\nJZHmP1qP8KPNEWTI8Q76ue4Q3aiA53EQguzGb3SEtyp36JGBq05Jor9erEebFftVl83NFvio72Fn\n0N2xvu8zCnlylf2hpz9x1i01Xnz5UNtZ2ppsf2zzT+4U6w3frH+pkp0RDPuoe9mnBF001AguP31h\nSBZyZzWcwQltuNELnSRCcgJl4kC2h3mAgaVtYalrFxLRa3tA2XF2BHRHmKgocedVhTq+81xrqj+W\nQuDmUe06DnrS3Ohmyj3jhsCCluznAolmrBhT/SaDuGg=\n-----END CERTIFICATE-----\n"
+			# No id supplied for the cert
+			}
+		},
+		]
+      digital_signature = false
+      http_basic_credentials = {
+        encrypted_password = "OBF:JWE:eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2Iiwia2lkIjoiUWVzOVR5eTV5WiIsInZlcnNpb24iOiIxMi4xLjMuMCJ9..Q7cuD9L9LT5W8VKdl32iOQ.4AqqdVvegqo6vQxJBc1sBZckQgjxaCrSssbiCaQV3B_ijayEtLePXRCtLUE8P9-U8526lbVee7t93rrByvapYw.PgMT-r6-kKm8TJrmP7-MHg"
+        password           = null # sensitive
+        username           = "anotheruser"
+      }
+      require_ssl             = true
+      verification_issuer_dn  = null
+      verification_subject_dn = null
+    }
+    outbound_back_channel_auth = {
+      digital_signature = false
+      http_basic_credentials = {
+        password = "2FederateM0re"
+        username = "user"
+      }
+      validate_partner_cert = true
+    }
+    signing_settings = {
+      algorithm                    = "SHA256withRSA"
+      include_cert_in_signature    = false
+      include_raw_key_in_signature = false
+      signing_key_pair_ref = {
+        id = "419x9yg43rlawqwq9v6az997k"
+      }
+    }
+  }
+  default_virtual_entity_id = "example2"
+  entity_id                 = "myEntity"
+  extended_properties = {
+    authNexp = {
+      values = ["val1"]
+    }
+    useAuthnApi = {
+      values = ["val2"]
+    }
+  }
+  logging_mode = "STANDARD"
+  metadata_reload_settings = {
+    metadata_url_ref = {
+      id = pingfederate_metadata_url.metadataUrl.id
+    }
+    enable_auto_metadata_update = false
+  }
+  name = "mySpConn"
+  sp_browser_sso = {
+    adapter_mappings = [
+    ]
+    always_sign_artifact_response = true
+    artifact = {
+      resolver_locations = [
+        {
+          index = 1
+          url   = "https://example.com/endpoint"
+        },
+      ]
+    }
+    assertion_lifetime = {
+      minutes_after  = 5
+      minutes_before = 5
+    }
+    attribute_contract = {
+      core_attributes = [
+        {
+          name        = "SAML_SUBJECT"
+          name_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+        },
+      ]
+      extended_attributes = [
+      ]
+    }
+    authentication_policy_contract_assertion_mappings = [
+      {
+        abort_sso_transaction_as_fail_safe = false
+        attribute_contract_fulfillment = {
+          SAML_SUBJECT = {
+            source = {
+              type = "AUTHENTICATION_POLICY_CONTRACT"
+            }
+            value = "subject"
+          }
+        }
+        attribute_sources = [
+          {
+            custom_attribute_source = null
+            jdbc_attribute_source = {
+              attribute_contract_fulfillment = null
+              column_names                   = ["GRANTEE"]
+              data_store_ref = {
+                id = "ProvisionerDS"
+              }
+              description = "JDBC"
+              filter      = "example"
+              id          = "jdbcattrsource"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
+            }
+            ldap_attribute_source = null
+          },
+        ]
+        authentication_policy_contract_ref = {
+          id = "QGxlec5CX693lBQL"
+        }
+        issuance_criteria = {
+          conditional_criteria = [
+            {
+              attribute_name = "SAML_SUBJECT"
+              condition      = "MULTIVALUE_CONTAINS_DN"
+              error_result   = "myerrorresult"
+              source = {
+                type = "MAPPED_ATTRIBUTES"
+              }
+              value = "cn=Example,dc=example,dc=com"
+            },
+          ]
+        }
+        restrict_virtual_entity_ids   = false
+        restricted_virtual_entity_ids = []
+      },
+    ]
+    default_target_url = "https://example.com"
+    enabled_profiles   = ["IDP_INITIATED_SLO", "IDP_INITIATED_SSO"]
+    encryption_policy = {
+      encrypt_assertion             = true
+      encrypt_slo_subject_name_id   = false
+      encrypted_attributes          = []
+      slo_subject_name_id_encrypted = false
+    }
+    incoming_bindings = ["ARTIFACT", "POST", "REDIRECT", "SOAP"]
+    message_customizations = [
+    ]
+    protocol                      = "SAML20"
+    require_signed_authn_requests = false
+    sign_assertions               = true
+    sign_response_as_required     = true
+    slo_service_endpoints = [
+      {
+        binding      = "POST"
+        response_url = "/response"
+        url          = "/artifact"
+      },
+    ]
+    sp_saml_identity_mapping = "STANDARD"
+    sso_service_endpoints = [
+      {
+        binding    = "POST"
+        index      = 0
+        is_default = true
+        url        = "https://httpbin.org/anything"
+      },
+    ]
+  }
+  virtual_entity_ids = [
+    "example1",
+    "example2"
+  ]
+}
+`, idpSpConnection_SamlDependencyHCL(), id)
+}

--- a/internal/acctest/config/idp/spconnection/idp_sp_connection_resource_gen_drift_test.go
+++ b/internal/acctest/config/idp/spconnection/idp_sp_connection_resource_gen_drift_test.go
@@ -22,7 +22,7 @@ func TestAccIdpSpConnection_RemovalDrift(t *testing.T) {
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
 			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
 		},
-		CheckDestroy: spIdpConnection_SimpleCheckDestroy,
+		CheckDestroy: idpSpConnection_SimpleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Create the resource with a minimal model
@@ -31,7 +31,7 @@ func TestAccIdpSpConnection_RemovalDrift(t *testing.T) {
 			{
 				// Delete the resource on the service, outside of terraform, verify that a non-empty plan is generated
 				PreConfig: func() {
-					spIdpConnection_Delete(t, idpSpConnId)
+					idpSpConnection_Delete(t, idpSpConnId)
 				},
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
@@ -41,7 +41,7 @@ func TestAccIdpSpConnection_RemovalDrift(t *testing.T) {
 }
 
 // Delete the resource
-func spIdpConnection_Delete(t *testing.T, id string) {
+func idpSpConnection_Delete(t *testing.T, id string) {
 	testClient := acctest.TestClient()
 	_, err := testClient.IdpSpConnectionsAPI.DeleteSpConnection(acctest.TestBasicAuthContext(), id).Execute()
 	if err != nil {
@@ -50,7 +50,7 @@ func spIdpConnection_Delete(t *testing.T, id string) {
 }
 
 // Test that any objects created by the test are destroyed
-func spIdpConnection_SimpleCheckDestroy(s *terraform.State) error {
+func idpSpConnection_SimpleCheckDestroy(s *terraform.State) error {
 	testClient := acctest.TestClient()
 	_, err := testClient.IdpSpConnectionsAPI.DeleteSpConnection(acctest.TestBasicAuthContext(), idpSpConnId).Execute()
 	if err == nil {

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
@@ -1,0 +1,457 @@
+// Copyright © 2025 Ping Identity Corporation
+
+package resource_sp_idp_connection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest/common/accesstokenmanager"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/provider"
+)
+
+func TestAccSpIdpConnection_CertificateId(t *testing.T) {
+	connId := "certidconn"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: spIdpConnection_SimpleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Test applying two certs without defined ids in credentials
+				Config: spIdpConnection_CredentialsCertNoId(connId),
+			},
+		},
+	})
+}
+
+func spIdpConnection_CredentialsCertNoId(id string) string {
+	return fmt.Sprintf(`
+  %s
+  
+  resource "pingfederate_sp_idp_connection" "example" {
+    connection_id             = "%s"
+    active                    = true
+    name                      = "connection name"
+    entity_id                 = "entity_id"
+    logging_mode              = "STANDARD"
+    virtual_entity_ids        = ["virtual_server_id"]
+    base_url                  = "https://example.com"
+    default_virtual_entity_id = "virtual_server_id"
+    error_page_msg_id         = "errorDetail.spSsoFailure"
+  
+    attribute_query = {
+      url = "https://example.com"
+      name_mappings = [
+        {
+          local_name  = "local name"
+          remote_name = "remote name"
+        }
+      ]
+      policy = {
+        sign_attribute_query        = true
+        encrypt_name_id             = true
+        require_signed_response     = true
+        require_signed_assertion    = true
+        require_encrypted_assertion = true
+        mask_attribute_values       = true
+      }
+    }
+  
+    contact_info = {
+      first_name = "test"
+      last_name  = "test"
+      phone      = "555-5555"
+      email      = "test@test.com"
+      company    = "Ping Identity"
+    }
+  
+    idp_browser_sso = {
+      protocol = "SAML20"
+      enabled_profiles = [
+        "IDP_INITIATED_SSO"
+      ]
+      incoming_bindings = [
+        "POST"
+      ]
+      default_target_url            = "https://example.com"
+      always_sign_artifact_response = false
+      decryption_policy = {
+        assertion_encrypted           = false
+        subject_name_id_encrypted     = false
+        attributes_encrypted          = false
+        slo_encrypt_subject_name_id   = false
+        slo_subject_name_id_encrypted = false
+      }
+      idp_identity_mapping = "ACCOUNT_MAPPING"
+      attribute_contract = {
+        extended_attributes = []
+      }
+      adapter_mappings = [
+        {
+          attribute_sources = [
+            {
+              ldap_attribute_source = {
+                attribute_contract_fulfillment = null
+                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                binary_attribute_settings      = null
+                data_store_ref = {
+                  id = "pingdirectory"
+                }
+                description            = "PingDirectory"
+                member_of_nested_group = false
+                search_attributes      = ["Subject DN"]
+                search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                search_scope           = "SUBTREE"
+                type                   = "LDAP"
+              }
+            },
+          ]
+          attribute_contract_fulfillment = {
+            subject = {
+              source = {
+                type = "NO_MAPPING"
+              }
+            }
+          }
+          restrict_virtual_entity_ids   = false
+          restricted_virtual_entity_ids = []
+          sp_adapter_ref = {
+            id = "spadapter",
+          }
+        }
+      ]
+      authentication_policy_contract_mappings = [
+        {
+          attribute_sources = [
+            {
+              ldap_attribute_source = {
+                attribute_contract_fulfillment = null
+                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+                binary_attribute_settings      = null
+                data_store_ref = {
+                  id = "pingdirectory"
+                }
+                description            = "PingDirectory"
+                id                     = "LDAP"
+                member_of_nested_group = false
+                search_attributes      = ["Subject DN"]
+                search_filter          = "(&(memberUid=uid)(cn=Postman))"
+                search_scope           = "SUBTREE"
+                type                   = "LDAP"
+              }
+            },
+          ]
+          attribute_contract_fulfillment = {
+            "firstName" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            },
+            "lastName" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            },
+            "ImmutableID" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            },
+            "mail" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            },
+            "subject" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            },
+            "SAML_AUTHN_CTX" : {
+              source = {
+                type = "NO_MAPPING"
+              }
+            }
+          }
+          issuance_criteria = {
+            conditional_criteria = [
+              {
+                error_result = "error",
+                source = {
+                  type = "ASSERTION"
+                },
+                attribute_name = "SAML_SUBJECT",
+                condition      = "EQUALS",
+                value          = "value"
+              }
+            ]
+          }
+  
+          authentication_policy_contract_ref = {
+            id = "default"
+          }
+  
+          restrict_virtual_server_ids   = true
+          restricted_virtual_server_ids = ["virtual_server_id"]
+        }
+      ]
+      assertions_signed   = false
+      sign_authn_requests = false
+  
+      sso_oauth_mapping = {
+        attribute_sources = [
+          {
+            jdbc_attribute_source = {
+              data_store_ref = {
+                id = "ProvisionerDS",
+              },
+              description = "JDBC",
+              schema      = "INFORMATION_SCHEMA",
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS",
+              filter      = "example",
+              column_names = [
+                "GRANTEE"
+              ]
+            }
+          }
+        ]
+        attribute_contract_fulfillment = {
+          "USER_NAME" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          },
+          "USER_KEY" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          }
+        },
+      }
+    }
+  
+    credentials = {
+      certs = [{
+        x509_file = {
+          # No id supplied for the cert
+          file_data = "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjugAwIBAgIQPEkZGqCnSpsZf0jWCWxJ5jALBgkqhkiG9w0BAQswRzEL\nMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGjAYBgNV\nBAMMEUV4YW1wbGUgQXV0aG9yaXR5MB4XDTI0MDEwMTAwMDAwMFoXDTQzMTIyNzAw\nMDAwMFowRzELMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRp\nb24xGjAYBgNVBAMMEUV4YW1wbGUgQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzdxT13IA0xJ8rB1hkqxa/JTTrmLnNjTRnVJdwagGKThQ\nxpWqh0DchNMqXTaFNGgxia3hPB53ew7nEMuIf+Qfq4meexKL3yRg86Ng56BrGbsu\nK6z4ptRpdnmsxgkpEfGytdmUFkPXAGE6j4Td/UrAWByz7C9yl7qzFYeorWq5nABc\nIiOlLxBYXX3fOu3a44SNexNgl5dDJAtn8mosQ19wJcjm08fKRqHeWYvBV99kQlhW\na7WiTxdrbUZOrUMHYRuKO/JD732dcpnsar9HfjQi+PH3gCgw4NJNuBKzLv6t8DzZ\nnNxaiKgZ+5cxdhhRAe98MF0QeTbymjVLyoFBpMrRDQIDAQABoz0wOzAdBgNVHQ4E\nFgQUGNJsUqA63OVS8ouwVUkzaEP5vawwDAYDVR0TBAUwAwEB/zAMBgNVHQ8EBQMD\nBwYAMAsGCSqGSIb3DQEBCwOCAQEAGFvsWv35ipg0NNnq0x+e7Gtugn9OBhxkeTWo\nQ1IUR7CL9zMRdlErIx5waptJhlPZFZANVpuvYa+yRz7oz2txH8yf/0N+F0bTeNU/\nqZHenvp9RXzimxTFDoCkx7ESpW9b7IKSSZA6Zut6w7XzJeXRrNKfCSSrUGPfkCq4\nhOtAm9QzUVE7eJ5a7T3+O50gZdoxjdojPhh9h5E1b+bmexrfQKlVl/gL+KPacBJD\nbSxbiKECt5QGRdDGFFfoInhK1RiW7a/hQBhMWRsMiOFtu0YpfxfwIyIaK5QfHZBC\nCC7JaJKg19njrnkjfmiBGoev7XiYWYt/WvYAiZR4nJn/cFrW1A==\n-----END CERTIFICATE-----"
+        }
+        active_verification_cert    = true
+        encryption_cert             = true
+        primary_verification_cert   = true
+        secondary_verification_cert = false
+      }]
+  
+      inbound_back_channel_auth = {
+        http_basic_credentials = {
+          username = "admin"
+          password = "2FederateM0re!"
+        },
+        digital_signature = true
+        require_ssl       = true
+        certs = [{
+          x509_file = {
+            # No id supplied for the cert
+            file_data = "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjugAwIBAgIQPEkZGqCnSpsZf0jWCWxJ5jALBgkqhkiG9w0BAQswRzEL\nMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGjAYBgNV\nBAMMEUV4YW1wbGUgQXV0aG9yaXR5MB4XDTI0MDEwMTAwMDAwMFoXDTQzMTIyNzAw\nMDAwMFowRzELMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRp\nb24xGjAYBgNVBAMMEUV4YW1wbGUgQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzdxT13IA0xJ8rB1hkqxa/JTTrmLnNjTRnVJdwagGKThQ\nxpWqh0DchNMqXTaFNGgxia3hPB53ew7nEMuIf+Qfq4meexKL3yRg86Ng56BrGbsu\nK6z4ptRpdnmsxgkpEfGytdmUFkPXAGE6j4Td/UrAWByz7C9yl7qzFYeorWq5nABc\nIiOlLxBYXX3fOu3a44SNexNgl5dDJAtn8mosQ19wJcjm08fKRqHeWYvBV99kQlhW\na7WiTxdrbUZOrUMHYRuKO/JD732dcpnsar9HfjQi+PH3gCgw4NJNuBKzLv6t8DzZ\nnNxaiKgZ+5cxdhhRAe98MF0QeTbymjVLyoFBpMrRDQIDAQABoz0wOzAdBgNVHQ4E\nFgQUGNJsUqA63OVS8ouwVUkzaEP5vawwDAYDVR0TBAUwAwEB/zAMBgNVHQ8EBQMD\nBwYAMAsGCSqGSIb3DQEBCwOCAQEAGFvsWv35ipg0NNnq0x+e7Gtugn9OBhxkeTWo\nQ1IUR7CL9zMRdlErIx5waptJhlPZFZANVpuvYa+yRz7oz2txH8yf/0N+F0bTeNU/\nqZHenvp9RXzimxTFDoCkx7ESpW9b7IKSSZA6Zut6w7XzJeXRrNKfCSSrUGPfkCq4\nhOtAm9QzUVE7eJ5a7T3+O50gZdoxjdojPhh9h5E1b+bmexrfQKlVl/gL+KPacBJD\nbSxbiKECt5QGRdDGFFfoInhK1RiW7a/hQBhMWRsMiOFtu0YpfxfwIyIaK5QfHZBC\nCC7JaJKg19njrnkjfmiBGoev7XiYWYt/WvYAiZR4nJn/cFrW1A==\n-----END CERTIFICATE-----"
+          }
+          active_verification_cert    = true
+          encryption_cert             = false
+          primary_verification_cert   = true
+          secondary_verification_cert = false
+        }]
+      }
+  
+      decryption_key_pair_ref = {
+        id = "419x9yg43rlawqwq9v6az997k"
+      }
+  
+      signing_settings = {
+        signing_key_pair_ref = {
+          id = "419x9yg43rlawqwq9v6az997k"
+        }
+        algorithm                    = "SHA256withRSA"
+        include_cert_in_signature    = false
+        include_raw_key_in_signature = false
+      }
+  
+      block_encryption_algorithm = "AES_128"
+      key_transport_algorithm    = "RSA_OAEP"
+  
+      outbound_back_channel_auth = {
+        http_basic_credentials = {
+          username = "Administrator"
+          password = "2FederateM0re!"
+        }
+        digital_signature     = false
+        validate_partner_cert = true
+      }
+    }
+  
+    idp_oauth_grant_attribute_mapping = {
+      idp_oauth_attribute_contract = {
+        extended_attributes = []
+      }
+      access_token_manager_mappings = [
+        {
+          attribute_sources = [
+            {
+              custom_attribute_source = {
+                data_store_ref = {
+                  id = "customDataStore"
+                }
+                description = "APIStubs"
+                filter_fields = [
+                  {
+                    name = "Authorization Header"
+                  },
+                  {
+                    name = "Body"
+                  },
+                  {
+                    name  = "Resource Path"
+                    value = "/users/extid"
+                  },
+                ]
+                id = "APIStubs"
+              }
+            },
+          ]
+          attribute_contract_fulfillment = {
+            "Username" = {
+              source = {
+                type = "NO_MAPPING"
+              }
+            }
+            "OrgName" = {
+              source = {
+                type = "NO_MAPPING"
+              }
+            }
+          }
+          access_token_manager_ref = {
+            id = pingfederate_oauth_access_token_manager.idpConnCertNoIdAtm.id
+          }
+        }
+      ]
+    }
+  
+    ws_trust = {
+      attribute_contract = {
+        core_attributes = [
+          {
+            name   = "TOKEN_SUBJECT"
+            masked = false
+          }
+        ]
+        extended_attributes = [
+          {
+            name   = "test"
+            masked = false
+          }
+        ]
+      }
+      token_generator_mappings = [
+        {
+          attribute_contract_fulfillment = {
+            "SAML_SUBJECT" = {
+              source = {
+                type = "NO_MAPPING"
+              }
+            }
+          }
+          attribute_sources = [
+            {
+              custom_attribute_source = {
+                data_store_ref = {
+                  id = "customDataStore"
+                }
+                description = "APIStubs"
+                filter_fields = [
+                  {
+                    name = "Authorization Header"
+                  },
+                  {
+                    name = "Body"
+                  },
+                  {
+                    name  = "Resource Path"
+                    value = "/users/extid"
+                  },
+                ]
+                id = "APIStubs"
+              }
+            },
+          ]
+          sp_token_generator_ref = {
+            id = "tokengenerator"
+          }
+          default_mapping = true
+        }
+      ]
+      generate_local_token = true
+    }
+  
+    inbound_provisioning = {
+      group_support = false
+  
+      user_repository = {
+        identity_store = {
+          identity_store_provisioner_ref = {
+            id = "identityStoreProvisioner"
+          }
+        }
+      }
+  
+      custom_schema = {
+        namespace  = "urn:scim:schemas:extension:custom:1.0"
+        attributes = []
+      }
+  
+      users = {
+        write_users = {
+          attribute_fulfillment = {
+            "username" = {
+              source = {
+                type = "TEXT"
+              }
+              value = "username"
+            }
+          }
+        }
+  
+        read_users = {
+          attribute_contract = {
+            extended_attributes = [
+              {
+                name   = "userName"
+                masked = false
+              }
+            ]
+          }
+          attributes = []
+          attribute_fulfillment = {
+            "userName" = {
+              source = {
+                type = "TEXT"
+              }
+              value = "username"
+            }
+          }
+        }
+      }
+    }
+    # Ensures this resource will be updated before deleting the oauth access token manager
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
+  `, accesstokenmanager.AccessTokenManagerTestHCL("idpConnCertNoIdAtm"),
+		wsTrustStsConnId)
+}

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
@@ -34,424 +34,424 @@ func TestAccSpIdpConnection_CertificateId(t *testing.T) {
 func spIdpConnection_CredentialsCertNoId(id string) string {
 	return fmt.Sprintf(`
   %s
-  
-  resource "pingfederate_sp_idp_connection" "example" {
-    connection_id             = "%s"
-    active                    = true
-    name                      = "connection name"
-    entity_id                 = "entity_id"
-    logging_mode              = "STANDARD"
-    virtual_entity_ids        = ["virtual_server_id"]
-    base_url                  = "https://example.com"
-    default_virtual_entity_id = "virtual_server_id"
-    error_page_msg_id         = "errorDetail.spSsoFailure"
-  
-    attribute_query = {
-      url = "https://example.com"
-      name_mappings = [
-        {
-          local_name  = "local name"
-          remote_name = "remote name"
-        }
-      ]
-      policy = {
-        sign_attribute_query        = true
-        encrypt_name_id             = true
-        require_signed_response     = true
-        require_signed_assertion    = true
-        require_encrypted_assertion = true
-        mask_attribute_values       = true
+
+resource "pingfederate_sp_idp_connection" "example" {
+  connection_id             = "%s"
+  active                    = true
+  name                      = "connection name"
+  entity_id                 = "entity_id"
+  logging_mode              = "STANDARD"
+  virtual_entity_ids        = ["virtual_server_id"]
+  base_url                  = "https://example.com"
+  default_virtual_entity_id = "virtual_server_id"
+  error_page_msg_id         = "errorDetail.spSsoFailure"
+
+  attribute_query = {
+    url = "https://example.com"
+    name_mappings = [
+      {
+        local_name  = "local name"
+        remote_name = "remote name"
       }
+    ]
+    policy = {
+      sign_attribute_query        = true
+      encrypt_name_id             = true
+      require_signed_response     = true
+      require_signed_assertion    = true
+      require_encrypted_assertion = true
+      mask_attribute_values       = true
     }
-  
-    contact_info = {
-      first_name = "test"
-      last_name  = "test"
-      phone      = "555-5555"
-      email      = "test@test.com"
-      company    = "Ping Identity"
+  }
+
+  contact_info = {
+    first_name = "test"
+    last_name  = "test"
+    phone      = "555-5555"
+    email      = "test@test.com"
+    company    = "Ping Identity"
+  }
+
+  idp_browser_sso = {
+    protocol = "SAML20"
+    enabled_profiles = [
+      "IDP_INITIATED_SSO"
+    ]
+    incoming_bindings = [
+      "POST"
+    ]
+    default_target_url            = "https://example.com"
+    always_sign_artifact_response = false
+    decryption_policy = {
+      assertion_encrypted           = false
+      subject_name_id_encrypted     = false
+      attributes_encrypted          = false
+      slo_encrypt_subject_name_id   = false
+      slo_subject_name_id_encrypted = false
     }
-  
-    idp_browser_sso = {
-      protocol = "SAML20"
-      enabled_profiles = [
-        "IDP_INITIATED_SSO"
-      ]
-      incoming_bindings = [
-        "POST"
-      ]
-      default_target_url            = "https://example.com"
-      always_sign_artifact_response = false
-      decryption_policy = {
-        assertion_encrypted           = false
-        subject_name_id_encrypted     = false
-        attributes_encrypted          = false
-        slo_encrypt_subject_name_id   = false
-        slo_subject_name_id_encrypted = false
-      }
-      idp_identity_mapping = "ACCOUNT_MAPPING"
-      attribute_contract = {
-        extended_attributes = []
-      }
-      adapter_mappings = [
-        {
-          attribute_sources = [
-            {
-              ldap_attribute_source = {
-                attribute_contract_fulfillment = null
-                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                binary_attribute_settings      = null
-                data_store_ref = {
-                  id = "pingdirectory"
-                }
-                description            = "PingDirectory"
-                member_of_nested_group = false
-                search_attributes      = ["Subject DN"]
-                search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                search_scope           = "SUBTREE"
-                type                   = "LDAP"
-              }
-            },
-          ]
-          attribute_contract_fulfillment = {
-            subject = {
-              source = {
-                type = "NO_MAPPING"
-              }
-            }
-          }
-          restrict_virtual_entity_ids   = false
-          restricted_virtual_entity_ids = []
-          sp_adapter_ref = {
-            id = "spadapter",
-          }
-        }
-      ]
-      authentication_policy_contract_mappings = [
-        {
-          attribute_sources = [
-            {
-              ldap_attribute_source = {
-                attribute_contract_fulfillment = null
-                base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-                binary_attribute_settings      = null
-                data_store_ref = {
-                  id = "pingdirectory"
-                }
-                description            = "PingDirectory"
-                id                     = "LDAP"
-                member_of_nested_group = false
-                search_attributes      = ["Subject DN"]
-                search_filter          = "(&(memberUid=uid)(cn=Postman))"
-                search_scope           = "SUBTREE"
-                type                   = "LDAP"
-              }
-            },
-          ]
-          attribute_contract_fulfillment = {
-            "firstName" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            },
-            "lastName" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            },
-            "ImmutableID" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            },
-            "mail" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            },
-            "subject" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            },
-            "SAML_AUTHN_CTX" : {
-              source = {
-                type = "NO_MAPPING"
-              }
-            }
-          }
-          issuance_criteria = {
-            conditional_criteria = [
-              {
-                error_result = "error",
-                source = {
-                  type = "ASSERTION"
-                },
-                attribute_name = "SAML_SUBJECT",
-                condition      = "EQUALS",
-                value          = "value"
-              }
-            ]
-          }
-  
-          authentication_policy_contract_ref = {
-            id = "default"
-          }
-  
-          restrict_virtual_server_ids   = true
-          restricted_virtual_server_ids = ["virtual_server_id"]
-        }
-      ]
-      assertions_signed   = false
-      sign_authn_requests = false
-  
-      sso_oauth_mapping = {
+    idp_identity_mapping = "ACCOUNT_MAPPING"
+    attribute_contract = {
+      extended_attributes = []
+    }
+    adapter_mappings = [
+      {
         attribute_sources = [
           {
-            jdbc_attribute_source = {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
               data_store_ref = {
-                id = "ProvisionerDS",
-              },
-              description = "JDBC",
-              schema      = "INFORMATION_SCHEMA",
-              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS",
-              filter      = "example",
-              column_names = [
-                "GRANTEE"
-              ]
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
             }
-          }
+          },
         ]
         attribute_contract_fulfillment = {
-          "USER_NAME" : {
+          subject = {
+            source = {
+              type = "NO_MAPPING"
+            }
+          }
+        }
+        restrict_virtual_entity_ids   = false
+        restricted_virtual_entity_ids = []
+        sp_adapter_ref = {
+          id = "spadapter",
+        }
+      }
+    ]
+    authentication_policy_contract_mappings = [
+      {
+        attribute_sources = [
+          {
+            ldap_attribute_source = {
+              attribute_contract_fulfillment = null
+              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
+              binary_attribute_settings      = null
+              data_store_ref = {
+                id = "pingdirectory"
+              }
+              description            = "PingDirectory"
+              id                     = "LDAP"
+              member_of_nested_group = false
+              search_attributes      = ["Subject DN"]
+              search_filter          = "(&(memberUid=uid)(cn=Postman))"
+              search_scope           = "SUBTREE"
+              type                   = "LDAP"
+            }
+          },
+        ]
+        attribute_contract_fulfillment = {
+          "firstName" : {
             source = {
               type = "NO_MAPPING"
             }
           },
-          "USER_KEY" : {
+          "lastName" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          },
+          "ImmutableID" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          },
+          "mail" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          },
+          "subject" : {
+            source = {
+              type = "NO_MAPPING"
+            }
+          },
+          "SAML_AUTHN_CTX" : {
             source = {
               type = "NO_MAPPING"
             }
           }
-        },
+        }
+        issuance_criteria = {
+          conditional_criteria = [
+            {
+              error_result = "error",
+              source = {
+                type = "ASSERTION"
+              },
+              attribute_name = "SAML_SUBJECT",
+              condition      = "EQUALS",
+              value          = "value"
+            }
+          ]
+        }
+
+        authentication_policy_contract_ref = {
+          id = "default"
+        }
+
+        restrict_virtual_server_ids   = true
+        restricted_virtual_server_ids = ["virtual_server_id"]
       }
+    ]
+    assertions_signed   = false
+    sign_authn_requests = false
+
+    sso_oauth_mapping = {
+      attribute_sources = [
+        {
+          jdbc_attribute_source = {
+            data_store_ref = {
+              id = "ProvisionerDS",
+            },
+            description = "JDBC",
+            schema      = "INFORMATION_SCHEMA",
+            table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS",
+            filter      = "example",
+            column_names = [
+              "GRANTEE"
+            ]
+          }
+        }
+      ]
+      attribute_contract_fulfillment = {
+        "USER_NAME" : {
+          source = {
+            type = "NO_MAPPING"
+          }
+        },
+        "USER_KEY" : {
+          source = {
+            type = "NO_MAPPING"
+          }
+        }
+      },
     }
-  
-    credentials = {
+  }
+
+  credentials = {
+    certs = [{
+      x509_file = {
+        # No id supplied for the cert
+        file_data = "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjugAwIBAgIQPEkZGqCnSpsZf0jWCWxJ5jALBgkqhkiG9w0BAQswRzEL\nMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGjAYBgNV\nBAMMEUV4YW1wbGUgQXV0aG9yaXR5MB4XDTI0MDEwMTAwMDAwMFoXDTQzMTIyNzAw\nMDAwMFowRzELMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRp\nb24xGjAYBgNVBAMMEUV4YW1wbGUgQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzdxT13IA0xJ8rB1hkqxa/JTTrmLnNjTRnVJdwagGKThQ\nxpWqh0DchNMqXTaFNGgxia3hPB53ew7nEMuIf+Qfq4meexKL3yRg86Ng56BrGbsu\nK6z4ptRpdnmsxgkpEfGytdmUFkPXAGE6j4Td/UrAWByz7C9yl7qzFYeorWq5nABc\nIiOlLxBYXX3fOu3a44SNexNgl5dDJAtn8mosQ19wJcjm08fKRqHeWYvBV99kQlhW\na7WiTxdrbUZOrUMHYRuKO/JD732dcpnsar9HfjQi+PH3gCgw4NJNuBKzLv6t8DzZ\nnNxaiKgZ+5cxdhhRAe98MF0QeTbymjVLyoFBpMrRDQIDAQABoz0wOzAdBgNVHQ4E\nFgQUGNJsUqA63OVS8ouwVUkzaEP5vawwDAYDVR0TBAUwAwEB/zAMBgNVHQ8EBQMD\nBwYAMAsGCSqGSIb3DQEBCwOCAQEAGFvsWv35ipg0NNnq0x+e7Gtugn9OBhxkeTWo\nQ1IUR7CL9zMRdlErIx5waptJhlPZFZANVpuvYa+yRz7oz2txH8yf/0N+F0bTeNU/\nqZHenvp9RXzimxTFDoCkx7ESpW9b7IKSSZA6Zut6w7XzJeXRrNKfCSSrUGPfkCq4\nhOtAm9QzUVE7eJ5a7T3+O50gZdoxjdojPhh9h5E1b+bmexrfQKlVl/gL+KPacBJD\nbSxbiKECt5QGRdDGFFfoInhK1RiW7a/hQBhMWRsMiOFtu0YpfxfwIyIaK5QfHZBC\nCC7JaJKg19njrnkjfmiBGoev7XiYWYt/WvYAiZR4nJn/cFrW1A==\n-----END CERTIFICATE-----"
+      }
+      active_verification_cert    = true
+      encryption_cert             = true
+      primary_verification_cert   = true
+      secondary_verification_cert = false
+    }]
+
+    inbound_back_channel_auth = {
+      http_basic_credentials = {
+        username = "admin"
+        password = "2FederateM0re!"
+      },
+      digital_signature = true
+      require_ssl       = true
       certs = [{
         x509_file = {
           # No id supplied for the cert
           file_data = "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjugAwIBAgIQPEkZGqCnSpsZf0jWCWxJ5jALBgkqhkiG9w0BAQswRzEL\nMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGjAYBgNV\nBAMMEUV4YW1wbGUgQXV0aG9yaXR5MB4XDTI0MDEwMTAwMDAwMFoXDTQzMTIyNzAw\nMDAwMFowRzELMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRp\nb24xGjAYBgNVBAMMEUV4YW1wbGUgQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzdxT13IA0xJ8rB1hkqxa/JTTrmLnNjTRnVJdwagGKThQ\nxpWqh0DchNMqXTaFNGgxia3hPB53ew7nEMuIf+Qfq4meexKL3yRg86Ng56BrGbsu\nK6z4ptRpdnmsxgkpEfGytdmUFkPXAGE6j4Td/UrAWByz7C9yl7qzFYeorWq5nABc\nIiOlLxBYXX3fOu3a44SNexNgl5dDJAtn8mosQ19wJcjm08fKRqHeWYvBV99kQlhW\na7WiTxdrbUZOrUMHYRuKO/JD732dcpnsar9HfjQi+PH3gCgw4NJNuBKzLv6t8DzZ\nnNxaiKgZ+5cxdhhRAe98MF0QeTbymjVLyoFBpMrRDQIDAQABoz0wOzAdBgNVHQ4E\nFgQUGNJsUqA63OVS8ouwVUkzaEP5vawwDAYDVR0TBAUwAwEB/zAMBgNVHQ8EBQMD\nBwYAMAsGCSqGSIb3DQEBCwOCAQEAGFvsWv35ipg0NNnq0x+e7Gtugn9OBhxkeTWo\nQ1IUR7CL9zMRdlErIx5waptJhlPZFZANVpuvYa+yRz7oz2txH8yf/0N+F0bTeNU/\nqZHenvp9RXzimxTFDoCkx7ESpW9b7IKSSZA6Zut6w7XzJeXRrNKfCSSrUGPfkCq4\nhOtAm9QzUVE7eJ5a7T3+O50gZdoxjdojPhh9h5E1b+bmexrfQKlVl/gL+KPacBJD\nbSxbiKECt5QGRdDGFFfoInhK1RiW7a/hQBhMWRsMiOFtu0YpfxfwIyIaK5QfHZBC\nCC7JaJKg19njrnkjfmiBGoev7XiYWYt/WvYAiZR4nJn/cFrW1A==\n-----END CERTIFICATE-----"
         }
         active_verification_cert    = true
-        encryption_cert             = true
+        encryption_cert             = false
         primary_verification_cert   = true
         secondary_verification_cert = false
       }]
-  
-      inbound_back_channel_auth = {
-        http_basic_credentials = {
-          username = "admin"
-          password = "2FederateM0re!"
-        },
-        digital_signature = true
-        require_ssl       = true
-        certs = [{
-          x509_file = {
-            # No id supplied for the cert
-            file_data = "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjugAwIBAgIQPEkZGqCnSpsZf0jWCWxJ5jALBgkqhkiG9w0BAQswRzEL\nMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGjAYBgNV\nBAMMEUV4YW1wbGUgQXV0aG9yaXR5MB4XDTI0MDEwMTAwMDAwMFoXDTQzMTIyNzAw\nMDAwMFowRzELMAkGA1UEBgwCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRp\nb24xGjAYBgNVBAMMEUV4YW1wbGUgQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzdxT13IA0xJ8rB1hkqxa/JTTrmLnNjTRnVJdwagGKThQ\nxpWqh0DchNMqXTaFNGgxia3hPB53ew7nEMuIf+Qfq4meexKL3yRg86Ng56BrGbsu\nK6z4ptRpdnmsxgkpEfGytdmUFkPXAGE6j4Td/UrAWByz7C9yl7qzFYeorWq5nABc\nIiOlLxBYXX3fOu3a44SNexNgl5dDJAtn8mosQ19wJcjm08fKRqHeWYvBV99kQlhW\na7WiTxdrbUZOrUMHYRuKO/JD732dcpnsar9HfjQi+PH3gCgw4NJNuBKzLv6t8DzZ\nnNxaiKgZ+5cxdhhRAe98MF0QeTbymjVLyoFBpMrRDQIDAQABoz0wOzAdBgNVHQ4E\nFgQUGNJsUqA63OVS8ouwVUkzaEP5vawwDAYDVR0TBAUwAwEB/zAMBgNVHQ8EBQMD\nBwYAMAsGCSqGSIb3DQEBCwOCAQEAGFvsWv35ipg0NNnq0x+e7Gtugn9OBhxkeTWo\nQ1IUR7CL9zMRdlErIx5waptJhlPZFZANVpuvYa+yRz7oz2txH8yf/0N+F0bTeNU/\nqZHenvp9RXzimxTFDoCkx7ESpW9b7IKSSZA6Zut6w7XzJeXRrNKfCSSrUGPfkCq4\nhOtAm9QzUVE7eJ5a7T3+O50gZdoxjdojPhh9h5E1b+bmexrfQKlVl/gL+KPacBJD\nbSxbiKECt5QGRdDGFFfoInhK1RiW7a/hQBhMWRsMiOFtu0YpfxfwIyIaK5QfHZBC\nCC7JaJKg19njrnkjfmiBGoev7XiYWYt/WvYAiZR4nJn/cFrW1A==\n-----END CERTIFICATE-----"
-          }
-          active_verification_cert    = true
-          encryption_cert             = false
-          primary_verification_cert   = true
-          secondary_verification_cert = false
-        }]
-      }
-  
-      decryption_key_pair_ref = {
+    }
+
+    decryption_key_pair_ref = {
+      id = "419x9yg43rlawqwq9v6az997k"
+    }
+
+    signing_settings = {
+      signing_key_pair_ref = {
         id = "419x9yg43rlawqwq9v6az997k"
       }
-  
-      signing_settings = {
-        signing_key_pair_ref = {
-          id = "419x9yg43rlawqwq9v6az997k"
-        }
-        algorithm                    = "SHA256withRSA"
-        include_cert_in_signature    = false
-        include_raw_key_in_signature = false
-      }
-  
-      block_encryption_algorithm = "AES_128"
-      key_transport_algorithm    = "RSA_OAEP"
-  
-      outbound_back_channel_auth = {
-        http_basic_credentials = {
-          username = "Administrator"
-          password = "2FederateM0re!"
-        }
-        digital_signature     = false
-        validate_partner_cert = true
-      }
+      algorithm                    = "SHA256withRSA"
+      include_cert_in_signature    = false
+      include_raw_key_in_signature = false
     }
-  
-    idp_oauth_grant_attribute_mapping = {
-      idp_oauth_attribute_contract = {
-        extended_attributes = []
+
+    block_encryption_algorithm = "AES_128"
+    key_transport_algorithm    = "RSA_OAEP"
+
+    outbound_back_channel_auth = {
+      http_basic_credentials = {
+        username = "Administrator"
+        password = "2FederateM0re!"
       }
-      access_token_manager_mappings = [
-        {
-          attribute_sources = [
-            {
-              custom_attribute_source = {
-                data_store_ref = {
-                  id = "customDataStore"
-                }
-                description = "APIStubs"
-                filter_fields = [
-                  {
-                    name = "Authorization Header"
-                  },
-                  {
-                    name = "Body"
-                  },
-                  {
-                    name  = "Resource Path"
-                    value = "/users/extid"
-                  },
-                ]
-                id = "APIStubs"
-              }
-            },
-          ]
-          attribute_contract_fulfillment = {
-            "Username" = {
-              source = {
-                type = "NO_MAPPING"
-              }
-            }
-            "OrgName" = {
-              source = {
-                type = "NO_MAPPING"
-              }
-            }
-          }
-          access_token_manager_ref = {
-            id = pingfederate_oauth_access_token_manager.idpConnCertNoIdAtm.id
-          }
-        }
-      ]
-    }
-  
-    ws_trust = {
-      attribute_contract = {
-        core_attributes = [
-          {
-            name   = "TOKEN_SUBJECT"
-            masked = false
-          }
-        ]
-        extended_attributes = [
-          {
-            name   = "test"
-            masked = false
-          }
-        ]
-      }
-      token_generator_mappings = [
-        {
-          attribute_contract_fulfillment = {
-            "SAML_SUBJECT" = {
-              source = {
-                type = "NO_MAPPING"
-              }
-            }
-          }
-          attribute_sources = [
-            {
-              custom_attribute_source = {
-                data_store_ref = {
-                  id = "customDataStore"
-                }
-                description = "APIStubs"
-                filter_fields = [
-                  {
-                    name = "Authorization Header"
-                  },
-                  {
-                    name = "Body"
-                  },
-                  {
-                    name  = "Resource Path"
-                    value = "/users/extid"
-                  },
-                ]
-                id = "APIStubs"
-              }
-            },
-          ]
-          sp_token_generator_ref = {
-            id = "tokengenerator"
-          }
-          default_mapping = true
-        }
-      ]
-      generate_local_token = true
-    }
-  
-    inbound_provisioning = {
-      group_support = false
-  
-      user_repository = {
-        identity_store = {
-          identity_store_provisioner_ref = {
-            id = "identityStoreProvisioner"
-          }
-        }
-      }
-  
-      custom_schema = {
-        namespace  = "urn:scim:schemas:extension:custom:1.0"
-        attributes = []
-      }
-  
-      users = {
-        write_users = {
-          attribute_fulfillment = {
-            "username" = {
-              source = {
-                type = "TEXT"
-              }
-              value = "username"
-            }
-          }
-        }
-  
-        read_users = {
-          attribute_contract = {
-            extended_attributes = [
-              {
-                name   = "userName"
-                masked = false
-              }
-            ]
-          }
-          attributes = []
-          attribute_fulfillment = {
-            "userName" = {
-              source = {
-                type = "TEXT"
-              }
-              value = "username"
-            }
-          }
-        }
-      }
-    }
-    # Ensures this resource will be updated before deleting the oauth access token manager
-    lifecycle {
-      create_before_destroy = true
+      digital_signature     = false
+      validate_partner_cert = true
     }
   }
+
+  idp_oauth_grant_attribute_mapping = {
+    idp_oauth_attribute_contract = {
+      extended_attributes = []
+    }
+    access_token_manager_mappings = [
+      {
+        attribute_sources = [
+          {
+            custom_attribute_source = {
+              data_store_ref = {
+                id = "customDataStore"
+              }
+              description = "APIStubs"
+              filter_fields = [
+                {
+                  name = "Authorization Header"
+                },
+                {
+                  name = "Body"
+                },
+                {
+                  name  = "Resource Path"
+                  value = "/users/extid"
+                },
+              ]
+              id = "APIStubs"
+            }
+          },
+        ]
+        attribute_contract_fulfillment = {
+          "Username" = {
+            source = {
+              type = "NO_MAPPING"
+            }
+          }
+          "OrgName" = {
+            source = {
+              type = "NO_MAPPING"
+            }
+          }
+        }
+        access_token_manager_ref = {
+          id = pingfederate_oauth_access_token_manager.idpConnCertNoIdAtm.id
+        }
+      }
+    ]
+  }
+
+  ws_trust = {
+    attribute_contract = {
+      core_attributes = [
+        {
+          name   = "TOKEN_SUBJECT"
+          masked = false
+        }
+      ]
+      extended_attributes = [
+        {
+          name   = "test"
+          masked = false
+        }
+      ]
+    }
+    token_generator_mappings = [
+      {
+        attribute_contract_fulfillment = {
+          "SAML_SUBJECT" = {
+            source = {
+              type = "NO_MAPPING"
+            }
+          }
+        }
+        attribute_sources = [
+          {
+            custom_attribute_source = {
+              data_store_ref = {
+                id = "customDataStore"
+              }
+              description = "APIStubs"
+              filter_fields = [
+                {
+                  name = "Authorization Header"
+                },
+                {
+                  name = "Body"
+                },
+                {
+                  name  = "Resource Path"
+                  value = "/users/extid"
+                },
+              ]
+              id = "APIStubs"
+            }
+          },
+        ]
+        sp_token_generator_ref = {
+          id = "tokengenerator"
+        }
+        default_mapping = true
+      }
+    ]
+    generate_local_token = true
+  }
+
+  inbound_provisioning = {
+    group_support = false
+
+    user_repository = {
+      identity_store = {
+        identity_store_provisioner_ref = {
+          id = "identityStoreProvisioner"
+        }
+      }
+    }
+
+    custom_schema = {
+      namespace  = "urn:scim:schemas:extension:custom:1.0"
+      attributes = []
+    }
+
+    users = {
+      write_users = {
+        attribute_fulfillment = {
+          "username" = {
+            source = {
+              type = "TEXT"
+            }
+            value = "username"
+          }
+        }
+      }
+
+      read_users = {
+        attribute_contract = {
+          extended_attributes = [
+            {
+              name   = "userName"
+              masked = false
+            }
+          ]
+        }
+        attributes = []
+        attribute_fulfillment = {
+          "userName" = {
+            source = {
+              type = "TEXT"
+            }
+            value = "username"
+          }
+        }
+      }
+    }
+  }
+  # Ensures this resource will be updated before deleting the oauth access token manager
+  lifecycle {
+    create_before_destroy = true
+  }
+}
   `, accesstokenmanager.AccessTokenManagerTestHCL("idpConnCertNoIdAtm"),
 		wsTrustStsConnId)
 }

--- a/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
+++ b/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
@@ -2846,6 +2846,7 @@ func (state *idpSpConnectionModel) readClientResponse(response *client.SpConnect
 				for _, certInPlan := range state.Credentials.Attributes()["certs"].(types.List).Elements() {
 					x509FilePlanAttrs := certInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 					x509FileIdPlan := x509FilePlanAttrs["id"].(types.String).ValueString()
+					//TODO right here
 					if cert.X509File.Id != nil && *cert.X509File.Id == x509FileIdPlan {
 						planFileData := x509FilePlanAttrs["file_data"].(types.String)
 						credentialsCertsObjValue, objDiags := connectioncert.ToState(context.Background(), planFileData, cert, &diags, isImportRead)
@@ -2888,6 +2889,7 @@ func (state *idpSpConnectionModel) readClientResponse(response *client.SpConnect
 						for _, ibcaCertInPlan := range state.Credentials.Attributes()["inbound_back_channel_auth"].(types.Object).Attributes()["certs"].(types.List).Elements() {
 							ibcax509FilePlanAttrs := ibcaCertInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 							ibcax509FileIdPlan := ibcax509FilePlanAttrs["id"].(types.String).ValueString()
+							//TODO right here
 							if ibcaCert.X509File.Id != nil && *ibcaCert.X509File.Id == ibcax509FileIdPlan {
 								planIbcaX509FileFileData := ibcax509FilePlanAttrs["file_data"].(types.String)
 								planIbcaX509FileFileDataCertsObjValue, objDiags := connectioncert.ToState(context.Background(), planIbcaX509FileFileData, ibcaCert, &diags, isImportRead)

--- a/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
+++ b/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/sourcetypeidkey"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/config"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/configvalidators"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/pemcertificates"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/providererror"
 	internaltypes "github.com/pingidentity/terraform-provider-pingfederate/internal/types"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/utils"
@@ -2846,8 +2847,11 @@ func (state *idpSpConnectionModel) readClientResponse(response *client.SpConnect
 				for _, certInPlan := range state.Credentials.Attributes()["certs"].(types.List).Elements() {
 					x509FilePlanAttrs := certInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 					x509FileIdPlan := x509FilePlanAttrs["id"].(types.String).ValueString()
-					//TODO right here
-					if cert.X509File.Id != nil && *cert.X509File.Id == x509FileIdPlan {
+					// If the plan did not define an id for the cert, we'll have to compare the certs via the file_data.
+					// Otherwise just compare the ids of the certs
+					if (x509FileIdPlan == "" &&
+						pemcertificates.FileDataEquivalent(x509FilePlanAttrs["file_data"].(types.String).ValueString(), cert.X509File.FileData)) ||
+						(cert.X509File.Id != nil && *cert.X509File.Id == x509FileIdPlan) {
 						planFileData := x509FilePlanAttrs["file_data"].(types.String)
 						credentialsCertsObjValue, objDiags := connectioncert.ToState(context.Background(), planFileData, cert, &diags, isImportRead)
 						respDiags.Append(objDiags...)
@@ -2889,8 +2893,11 @@ func (state *idpSpConnectionModel) readClientResponse(response *client.SpConnect
 						for _, ibcaCertInPlan := range state.Credentials.Attributes()["inbound_back_channel_auth"].(types.Object).Attributes()["certs"].(types.List).Elements() {
 							ibcax509FilePlanAttrs := ibcaCertInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 							ibcax509FileIdPlan := ibcax509FilePlanAttrs["id"].(types.String).ValueString()
-							//TODO right here
-							if ibcaCert.X509File.Id != nil && *ibcaCert.X509File.Id == ibcax509FileIdPlan {
+							// If the plan did not define an id for the cert, we'll have to compare the certs via the file_data.
+							// Otherwise just compare the ids of the certs
+							if (ibcax509FileIdPlan == "" &&
+								pemcertificates.FileDataEquivalent(ibcax509FilePlanAttrs["file_data"].(types.String).ValueString(), ibcaCert.X509File.FileData)) ||
+								(ibcaCert.X509File.Id != nil && *ibcaCert.X509File.Id == ibcax509FileIdPlan) {
 								planIbcaX509FileFileData := ibcax509FilePlanAttrs["file_data"].(types.String)
 								planIbcaX509FileFileDataCertsObjValue, objDiags := connectioncert.ToState(context.Background(), planIbcaX509FileFileData, ibcaCert, &diags, isImportRead)
 								respDiags.Append(objDiags...)

--- a/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
+++ b/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
@@ -4535,6 +4535,7 @@ func readSpIdpConnectionResponse(ctx context.Context, r *client.IdpConnection, p
 				for _, certInPlan := range plan.Credentials.Attributes()["certs"].(types.List).Elements() {
 					x509FilePlanAttrs := certInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 					x509FileIdPlan := x509FilePlanAttrs["id"].(types.String).ValueString()
+					//TODO right here
 					if cert.X509File.Id != nil && *cert.X509File.Id == x509FileIdPlan {
 						planFileData := x509FilePlanAttrs["file_data"].(types.String)
 						credentialsCertsObjValue, objDiags := connectioncert.ToState(ctx, planFileData, cert, &respDiags, isImportRead)
@@ -4577,6 +4578,7 @@ func readSpIdpConnectionResponse(ctx context.Context, r *client.IdpConnection, p
 						for _, ibcaCertInPlan := range plan.Credentials.Attributes()["inbound_back_channel_auth"].(types.Object).Attributes()["certs"].(types.List).Elements() {
 							ibcax509FilePlanAttrs := ibcaCertInPlan.(types.Object).Attributes()["x509_file"].(types.Object).Attributes()
 							ibcax509FileIdPlan := ibcax509FilePlanAttrs["id"].(types.String).ValueString()
+							//TODO right here
 							if ibcaCert.X509File.Id != nil && *ibcaCert.X509File.Id == ibcax509FileIdPlan {
 								planIbcaX509FileFileData := ibcax509FilePlanAttrs["file_data"].(types.String)
 								planIbcaX509FileFileDataCertsObjValue, objDiags := connectioncert.ToState(ctx, planIbcaX509FileFileData, ibcaCert, &respDiags, isImportRead)

--- a/internal/resource/pemcertificates/x509_compare_file_data.go
+++ b/internal/resource/pemcertificates/x509_compare_file_data.go
@@ -1,0 +1,27 @@
+package pemcertificates
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// Compare PEM encoded certificates, handling any formatting done by the PF API
+func FileDataEquivalent(planned, apiResponse string) bool {
+	var plannedFormatted, apiResponseFormatted, plannedBase64Decoded string
+
+	// Remove header, footer, and new lines
+	stringReplacer := strings.NewReplacer("-----BEGIN CERTIFICATE-----", "", "-----END CERTIFICATE-----", "", "\n", "")
+
+	plannedFormatted = stringReplacer.Replace(planned)
+	base64DecodedPlannedBytes, err := base64.StdEncoding.DecodeString(planned)
+	if err == nil {
+		// The plan value was base64-encoded, use the decoded value for comparison
+		plannedBase64Decoded = string(base64DecodedPlannedBytes)
+	}
+	plannedBase64Decoded = stringReplacer.Replace(plannedBase64Decoded)
+
+	apiResponseFormatted = stringReplacer.Replace(apiResponse)
+
+	// If the formatted versions match (base64 decoded or not), these represent the same certificate
+	return plannedFormatted == apiResponseFormatted || plannedBase64Decoded == apiResponseFormatted
+}

--- a/internal/resource/pemcertificates/x509_compare_file_data.go
+++ b/internal/resource/pemcertificates/x509_compare_file_data.go
@@ -1,3 +1,5 @@
+// Copyright © 2025 Ping Identity Corporation
+
 package pemcertificates
 
 import (

--- a/internal/resource/planmodifiers/x509_file_data_plan_modifier.go
+++ b/internal/resource/planmodifiers/x509_file_data_plan_modifier.go
@@ -4,13 +4,12 @@ package planmodifiers
 
 import (
 	"context"
-	"encoding/base64"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/pemcertificates"
 )
 
 var _ planmodifier.List = &x509FileData{}
@@ -53,35 +52,20 @@ func (v x509FileData) PlanModifyList(ctx context.Context, req planmodifier.ListR
 		stateCertViewValue := stateValueAttrs["cert_view"].(types.Object)
 		planCertViewValue := planValueAttrs["cert_view"].(types.Object)
 
-		var planFileDataStringFormatted, formattedFileDataAsStringFormatted, fileDataBase64Decoded string
-
-		// Remove header, footer, and new lines
-		stringReplacer := strings.NewReplacer("-----BEGIN CERTIFICATE-----", "", "-----END CERTIFICATE-----", "", "\n", "")
-
 		// Get file_data from plan
 		fileData, ok := planX509Value.Attributes()["file_data"]
 		if !ok {
 			return
 		}
-		planFileDataString := fileData.(types.String).ValueString()
-		planFileDataStringFormatted = stringReplacer.Replace(planFileDataString)
-		base64DecodedFileData, err := base64.StdEncoding.DecodeString(planFileDataString)
-		if err == nil {
-			// The plan value was base64-encoded, use the decoded value for comparison
-			fileDataBase64Decoded = string(base64DecodedFileData)
-		}
-		fileDataBase64Decoded = stringReplacer.Replace(fileDataBase64Decoded)
-
 		// Get formatted_file_data from state
 		formattedFileData, ok := stateX509Value.Attributes()["formatted_file_data"].(types.String)
 		if !ok {
 			return
 		}
-		formattedFileDataAsStringFormatted = stringReplacer.Replace(formattedFileData.ValueString())
 
 		// Check if formatted_file_data and file_data strings match, or if formatted_file_data matches original string
 		// If they do not, formatted_file_data is set to unknown
-		if formattedFileDataAsStringFormatted != fileDataBase64Decoded && formattedFileDataAsStringFormatted != planFileDataStringFormatted {
+		if !pemcertificates.FileDataEquivalent(fileData.(types.String).ValueString(), formattedFileData.ValueString()) {
 			reqPlanAttrs := planX509Value.Attributes()
 			reqPlanAttrs["formatted_file_data"] = types.StringUnknown()
 			planX509Value, respDiags = types.ObjectValue(planX509Value.AttributeTypes(ctx), reqPlanAttrs)

--- a/internal/resource/planmodifiers/x509_file_data_plan_modifier.go
+++ b/internal/resource/planmodifiers/x509_file_data_plan_modifier.go
@@ -88,7 +88,15 @@ func (v x509FileData) PlanModifyList(ctx context.Context, req planmodifier.ListR
 					"x509_file object did not build properly",
 				)
 			}
-			planCertViewValue, respDiags = types.ObjectValue(planCertViewValue.AttributeTypes(ctx), stateCertViewValue.Attributes())
+
+			certViewAttrs := stateCertViewValue.Attributes()
+			// Handle if the id was changed between the plan and state
+			planCertId := planX509Value.Attributes()["id"]
+			if !planCertId.IsUnknown() && !planCertId.IsNull() {
+				certViewAttrs["id"] = planCertId
+			}
+
+			planCertViewValue, respDiags = types.ObjectValue(planCertViewValue.AttributeTypes(ctx), certViewAttrs)
 			resp.Diagnostics.Append(respDiags...)
 			if respDiags.HasError() {
 				resp.Diagnostics.AddError(


### PR DESCRIPTION
- Prevent inconsistent result error that occurred when configuring certificates with no `id` value in the `pingfederate_sp_idp_connection` and `pingfederate_idp_sp_connection` resources.
- Fix inconsistent result error when changing the `id` of a certificate in those resources.