### PR TITLE
Handle file_data and formatted_file_data for three certificate resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.5.0 (Unreleased)
+### Enhancements
+* Added `formatted_file_data` field to `pingfederate_certificate_ca` and `pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate` resources, to handle drift detection when the certificate is changed outside of terraform. ([#502](https://github.com/pingidentity/terraform-provider-pingfederate/pull/502))
+
+### Bug fixes
+* Fixed the required `file_data` field not being written to state on import for the `pingfederate_certificate_ca`, `pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate`, and `pingfederate_metadata_url` resources. ([#502](https://github.com/pingidentity/terraform-provider-pingfederate/pull/502))
+
 # v1.4.5 April 30, 2025
 ### Bug fixes
 * Fixed an inconsistent result error that would occur when configuring certificates with no `id` value in the `pingfederate_idp_sp_connection` and `pingfederate_sp_idp_connection` resources. Also fixed a related inconsistent result failure that would occur when modifying the `id` of a certificate. ([#487](https://github.com/pingidentity/terraform-provider-pingfederate/pull/487))

--- a/docs/resources/certificate_ca.md
+++ b/docs/resources/certificate_ca.md
@@ -32,6 +32,7 @@ resource "pingfederate_certificate_ca" "example" {
 ### Read-Only
 
 - `expires` (String) The end date up until which the item is valid, in ISO 8601 format (UTC).
+- `formatted_file_data` (String) The certificate data in PEM format, formatted by PingFederate. This attribute is read-only.
 - `id` (String) The ID of this resource.
 - `issuer_dn` (String) The issuer's distinguished name.
 - `key_algorithm` (String) The public key algorithm.

--- a/docs/resources/server_settings_ws_trust_sts_settings_issuer_certificate.md
+++ b/docs/resources/server_settings_ws_trust_sts_settings_issuer_certificate.md
@@ -33,6 +33,7 @@ resource "pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate"
 
 - `active` (Boolean) Indicates whether this an active certificate or not.
 - `expires` (String) The end date up until which the item is valid, in ISO 8601 format (UTC).
+- `formatted_file_data` (String) The certificate data in PEM format, formatted by PingFederate. This attribute is read-only.
 - `id` (String) The ID of this resource.
 - `issuer_dn` (String) The issuer's distinguished name.
 - `key_algorithm` (String) The public key algorithm.

--- a/internal/acctest/config/certificates/ca/certificate_ca_resource_gen_test.go
+++ b/internal/acctest/config/certificates/ca/certificate_ca_resource_gen_test.go
@@ -85,7 +85,7 @@ func TestAccCertificateCa_MinimalMaximal(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "ca_id",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				// TODO currently the file_data isn't imported - see CDI-462
+				// The file_data is formatted by the server, so it may not match the config value on import
 				ImportStateVerifyIgnore: []string{"file_data"},
 			},
 		},

--- a/internal/acctest/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource_test.go
+++ b/internal/acctest/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource_test.go
@@ -109,7 +109,7 @@ func TestAccServerSettingsWsTrustStsSettingsIssuerCertificate_MinimalMaximal(t *
 				ImportStateVerifyIdentifierAttribute: "certificate_id",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				// File data is not returned by the API
+				// The file_data is formatted by the server, so it may not match the config value on import
 				ImportStateVerifyIgnore: []string{
 					"file_data",
 				},

--- a/internal/resource/common/connectioncert/connection_cert_schema.go
+++ b/internal/resource/common/connectioncert/connection_cert_schema.go
@@ -28,7 +28,7 @@ func ToSchema(description string, includeDefault bool) schema.ListNestedAttribut
 			listvalidator.UniqueValues(),
 		},
 		PlanModifiers: []planmodifier.List{
-			planmodifiers.ValidateX509FileData(),
+			planmodifiers.HandleFormattedCertsListFileData(),
 		},
 	}
 	if includeDefault {

--- a/internal/resource/config/certificates/ca/certificate_ca_resource.go
+++ b/internal/resource/config/certificates/ca/certificate_ca_resource.go
@@ -4,10 +4,10 @@ package certificatesca
 
 import (
 	"context"
+	"encoding/base64"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -17,8 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	client "github.com/pingidentity/pingfederate-go-client/v1220/configurationapi"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/id"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/importprivatestate"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/config"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/configvalidators"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/pemcertificates"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/providererror"
 	internaltypes "github.com/pingidentity/terraform-provider-pingfederate/internal/types"
 )
@@ -47,6 +49,7 @@ type certificatesResourceModel struct {
 	CryptoProvider          types.String `tfsdk:"crypto_provider"`
 	Expires                 types.String `tfsdk:"expires"`
 	FileData                types.String `tfsdk:"file_data"`
+	FormattedFileData       types.String `tfsdk:"formatted_file_data"`
 	Id                      types.String `tfsdk:"id"`
 	IssuerDn                types.String `tfsdk:"issuer_dn"`
 	KeyAlgorithm            types.String `tfsdk:"key_algorithm"`
@@ -104,6 +107,10 @@ func (r *certificateCAResource) Schema(ctx context.Context, req resource.SchemaR
 					stringvalidator.LengthAtLeast(1),
 					configvalidators.ValidBase64(),
 				},
+			},
+			"formatted_file_data": schema.StringAttribute{
+				Computed:    true,
+				Description: "The certificate data in PEM format, formatted by PingFederate. This attribute is read-only.",
 			},
 			"issuer_dn": schema.StringAttribute{
 				Computed:    true,
@@ -181,17 +188,41 @@ func (r *certificateCAResource) Configure(_ context.Context, req resource.Config
 	providerCfg := req.ProviderData.(internaltypes.ResourceConfiguration)
 	r.providerConfig = providerCfg.ProviderConfig
 	r.apiClient = providerCfg.ApiClient
-
 }
 
-func readCertificateResponse(ctx context.Context, r *client.CertView, state *certificatesResourceModel, expectedValues *certificatesResourceModel, diagnostics *diag.Diagnostics, createPlan types.String) {
-	X509FileData := createPlan
+func (r *certificateCAResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+	// Handle drift detection for the file_data value changing outside of terraform
+	var plan, state certificatesResourceModel
+	req.Plan.Get(ctx, &plan)
+	req.State.Get(ctx, &state)
+	if internaltypes.IsDefined(plan.FileData) && internaltypes.IsDefined(state.FormattedFileData) {
+		if !pemcertificates.FileDataEquivalent(plan.FileData.ValueString(), state.FormattedFileData.ValueString()) {
+			// Since file_data requires replacement on change, if drift is detected we need to replace the resource
+			plan.FormattedFileData = types.StringUnknown()
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+			resp.RequiresReplace = path.Paths{path.Root("formatted_file_data")}
+		}
+	}
+}
+
+func (state *certificatesResourceModel) readCertificateResponse(r *client.CertView, formattedPEM *string, isImportRead bool) {
 	state.CaId = types.StringPointerValue(r.Id)
 	state.Id = types.StringPointerValue(r.Id)
 	state.CryptoProvider = types.StringPointerValue(r.CryptoProvider)
-	state.FileData = types.StringValue(X509FileData.ValueString())
-	state.Id = types.StringPointerValue(r.Id)
-	state.CaId = types.StringPointerValue(r.Id)
+	if formattedPEM != nil {
+		if isImportRead {
+			// The PEM file must be in base-64 for the validator to accept it
+			state.FileData = types.StringValue(base64.StdEncoding.EncodeToString([]byte(*formattedPEM)))
+		}
+		state.FormattedFileData = types.StringPointerValue(formattedPEM)
+	} else {
+		// In theory this should never happen, but if the server fails to return the PEM file,
+		// just copy the value from the plan.
+		state.FormattedFileData = types.StringValue(state.FileData.ValueString())
+	}
 	state.SerialNumber = types.StringPointerValue(r.SerialNumber)
 	state.SubjectDn = types.StringPointerValue(r.SubjectDN)
 	state.SubjectAlternativeNames = internaltypes.GetStringSet(r.SubjectAlternativeNames)
@@ -231,35 +262,56 @@ func (r *certificateCAResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	// Read the response into the state
-	var state certificatesResourceModel
+	// Get the server's formatted PEM file for the cert
+	var pemFile *string
+	if certificateResponse.Id != nil {
+		exportedPemFile, httpResp, err := r.apiClient.CertificatesCaAPI.ExportCaCertificateFile(config.AuthContext(ctx, r.providerConfig), *certificateResponse.Id).Execute()
+		if err != nil {
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the PEM file of a CA certificate after create", err, httpResp, &caResourceCustomId)
+			return
+		}
+		pemFile = &exportedPemFile
+	}
 
-	readCertificateResponse(ctx, certificateResponse, &state, &plan, &resp.Diagnostics, plan.FileData)
-	diags = resp.State.Set(ctx, state)
-	resp.Diagnostics.Append(diags...)
+	// Read the response into the state
+	plan.readCertificateResponse(certificateResponse, pemFile, false)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *certificateCAResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	isImportRead, diags := importprivatestate.IsImportRead(ctx, req, resp)
+	resp.Diagnostics.Append(diags...)
 	var state certificatesResourceModel
 
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiReadCertificate, httpResp, err := r.apiClient.CertificatesCaAPI.GetTrustedCert(config.AuthContext(ctx, r.providerConfig), state.CaId.ValueString()).Execute()
+	certificateResponse, httpResp, err := r.apiClient.CertificatesCaAPI.GetTrustedCert(config.AuthContext(ctx, r.providerConfig), state.CaId.ValueString()).Execute()
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == 404 {
 			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Certificate CA", httpResp)
 			resp.State.RemoveResource(ctx)
 		} else {
-			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while looking for a Certificate", err, httpResp, &caResourceCustomId)
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading a CA certificate", err, httpResp, &caResourceCustomId)
+		}
+		return
+	}
+
+	// Get the server's formatted PEM file for the cert
+	exportedPemFile, httpResp, err := r.apiClient.CertificatesCaAPI.ExportCaCertificateFile(config.AuthContext(ctx, r.providerConfig), state.CaId.ValueString()).Execute()
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			config.AddResourceNotFoundWarning(ctx, &resp.Diagnostics, "Certificate CA", httpResp)
+			resp.State.RemoveResource(ctx)
+		} else {
+			config.ReportHttpErrorCustomId(ctx, &resp.Diagnostics, "An error occurred while reading the PEM file of a CA certificate", err, httpResp, &caResourceCustomId)
 		}
 		return
 	}
 
 	// Read the response into the state
-	readCertificateResponse(ctx, apiReadCertificate, &state, &state, &resp.Diagnostics, state.FileData)
+	state.readCertificateResponse(certificateResponse, &exportedPemFile, isImportRead)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -289,4 +341,5 @@ func (r *certificateCAResource) Delete(ctx context.Context, req resource.DeleteR
 
 func (r *certificateCAResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("ca_id"), req, resp)
+	importprivatestate.MarkPrivateStateForImport(ctx, resp)
 }

--- a/internal/resource/config/metadataurls/metadata_url_resource.go
+++ b/internal/resource/config/metadataurls/metadata_url_resource.go
@@ -15,23 +15,24 @@ import (
 )
 
 func (r *metadataUrlResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
 	// Handle drift detection for the x509_file.file_data value changing outside of terraform
-	if !req.Plan.Raw.IsNull() && !req.State.Raw.IsNull() {
-		var plan, state metadataUrlResourceModel
-		req.Plan.Get(ctx, &plan)
-		req.State.Get(ctx, &state)
-		if internaltypes.IsDefined(plan.X509File) && internaltypes.IsDefined(state.X509File) {
-			planX509Attrs := plan.X509File.Attributes()
-			planFileData := planX509Attrs["file_data"].(types.String).ValueString()
-			stateFormattedFileData := state.X509File.Attributes()["formatted_file_data"].(types.String).ValueString()
-			if !pemcertificates.FileDataEquivalent(planFileData, stateFormattedFileData) {
-				planX509Attrs["formatted_file_data"] = types.StringUnknown()
-				var diags diag.Diagnostics
-				plan.X509File, diags = types.ObjectValue(plan.X509File.AttributeTypes(ctx), planX509Attrs)
-				resp.Diagnostics.Append(diags...)
-				plan.CertView = types.ObjectUnknown(plan.CertView.AttributeTypes(ctx))
-				resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
-			}
+	var plan, state metadataUrlResourceModel
+	req.Plan.Get(ctx, &plan)
+	req.State.Get(ctx, &state)
+	if internaltypes.IsDefined(plan.X509File) && internaltypes.IsDefined(state.X509File) {
+		planX509Attrs := plan.X509File.Attributes()
+		planFileData := planX509Attrs["file_data"].(types.String).ValueString()
+		stateFormattedFileData := state.X509File.Attributes()["formatted_file_data"].(types.String).ValueString()
+		if !pemcertificates.FileDataEquivalent(planFileData, stateFormattedFileData) {
+			planX509Attrs["formatted_file_data"] = types.StringUnknown()
+			var diags diag.Diagnostics
+			plan.X509File, diags = types.ObjectValue(plan.X509File.AttributeTypes(ctx), planX509Attrs)
+			resp.Diagnostics.Append(diags...)
+			plan.CertView = types.ObjectUnknown(plan.CertView.AttributeTypes(ctx))
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 		}
 	}
 }

--- a/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
+++ b/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
@@ -19,8 +19,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	client "github.com/pingidentity/pingfederate-go-client/v1220/configurationapi"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/id"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/importprivatestate"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/config"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/configvalidators"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/pemcertificates"
 	internaltypes "github.com/pingidentity/terraform-provider-pingfederate/internal/types"
 )
 
@@ -60,6 +62,7 @@ type serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel struct {
 	CryptoProvider          types.String `tfsdk:"crypto_provider"`
 	Expires                 types.String `tfsdk:"expires"`
 	FileData                types.String `tfsdk:"file_data"`
+	FormattedFileData       types.String `tfsdk:"formatted_file_data"`
 	CertificateId           types.String `tfsdk:"certificate_id"`
 	Id                      types.String `tfsdk:"id"`
 	IssuerDn                types.String `tfsdk:"issuer_dn"`
@@ -106,6 +109,10 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Schema(ctx c
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
+			},
+			"formatted_file_data": schema.StringAttribute{
+				Computed:    true,
+				Description: "The certificate data in PEM format, formatted by PingFederate. This attribute is read-only.",
 			},
 			"certificate_id": schema.StringAttribute{
 				Optional:    true,
@@ -178,6 +185,24 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Schema(ctx c
 	id.ToSchema(&resp.Schema)
 }
 
+func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+	// Handle drift detection for the file_data value changing outside of terraform
+	var plan, state serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel
+	req.Plan.Get(ctx, &plan)
+	req.State.Get(ctx, &state)
+	if internaltypes.IsDefined(plan.FileData) && internaltypes.IsDefined(state.FormattedFileData) {
+		if !pemcertificates.FileDataEquivalent(plan.FileData.ValueString(), state.FormattedFileData.ValueString()) {
+			// Since file_data requires replacement on change, if drift is detected we need to replace the resource
+			plan.FormattedFileData = types.StringUnknown()
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+			resp.RequiresReplace = path.Paths{path.Root("formatted_file_data")}
+		}
+	}
+}
+
 func (model *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) buildClientStruct() (*client.X509File, diag.Diagnostics) {
 	result := &client.X509File{}
 	// crypto_provider
@@ -189,7 +214,7 @@ func (model *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) bui
 	return result, nil
 }
 
-func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) readClientResponse(response *client.IssuerCert) diag.Diagnostics {
+func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) readClientResponse(response *client.IssuerCert, isImportRead bool) diag.Diagnostics {
 	var respDiags, diags diag.Diagnostics
 	// id
 	state.Id = types.StringPointerValue(response.CertView.Id)
@@ -201,6 +226,12 @@ func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) rea
 	state.Expires = types.StringValue(response.CertView.Expires.Format(time.RFC3339))
 	// certificate_id
 	state.CertificateId = types.StringPointerValue(response.CertView.Id)
+	// on imports, read in the file_data value from the response
+	if isImportRead {
+		state.FileData = types.StringValue(response.X509File.FileData)
+	}
+	// formatted_file_data
+	state.FormattedFileData = types.StringValue(response.X509File.FileData)
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.CertView.IssuerDN)
 	// key_algorithm
@@ -251,13 +282,15 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Create(ctx c
 	}
 
 	// Read response into the model
-	resp.Diagnostics.Append(data.readClientResponse(responseData)...)
+	resp.Diagnostics.Append(data.readClientResponse(responseData, false)...)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	isImportRead, diags := importprivatestate.IsImportRead(ctx, req, resp)
+	resp.Diagnostics.Append(diags...)
 	var data serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel
 
 	// Read Terraform prior state data into the model
@@ -280,7 +313,7 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Read(ctx con
 	}
 
 	// Read response into the model
-	resp.Diagnostics.Append(data.readClientResponse(responseData)...)
+	resp.Diagnostics.Append(data.readClientResponse(responseData, isImportRead)...)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -310,4 +343,5 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Delete(ctx c
 func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to certificate_id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("certificate_id"), req, resp)
+	importprivatestate.MarkPrivateStateForImport(ctx, resp)
 }


### PR DESCRIPTION
Add new `formatted_file_data` field for drift detection, and write existing `file_data` values to state on import for `pingfederate_certificate_ca` and `pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate` resources.

Update `pingfederate_metadata_url` to correctly write existing `file_data` value to state on import.