### PR TITLE
Fix validation for idp_browser_sso.adapter_mappings.attribute_sources in pingfederate_sp_idp_connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 * Fixed the required `file_data` field not being written to state on import for the `pingfederate_certificate_ca`, `pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate`, and `pingfederate_metadata_url` resources. ([#502](https://github.com/pingidentity/terraform-provider-pingfederate/pull/502))
+* Fixed validation for the `idp_browser_sso.adapter_mappings.attribute_sources` attribute in the `pingfederate_sp_idp_connection` resource. The attribute sources are now limited to a maximum size of `1`, and the `id` attribute for the individual attribute sources is removed, as it is not supported in IdP connection adapter mappings. ([#503](https://github.com/pingidentity/terraform-provider-pingfederate/pull/503))
 
 # v1.4.5 April 30, 2025
 ### Bug fixes

--- a/docs/resources/sp_idp_connection.md
+++ b/docs/resources/sp_idp_connection.md
@@ -801,7 +801,6 @@ Optional:
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_browser_sso--adapter_mappings--attribute_sources--custom_attribute_source--attribute_contract_fulfillment))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter_fields` (Attributes Set) The list of fields that can be used to filter a request to the custom data store. (see [below for nested schema](#nestedatt--idp_browser_sso--adapter_mappings--attribute_sources--custom_attribute_source--filter_fields))
-- `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 
 Read-Only:
 
@@ -866,7 +865,6 @@ Optional:
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_browser_sso--adapter_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
 - `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
-- `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
 
 Read-Only:
@@ -922,7 +920,6 @@ Optional:
 - `base_dn` (String) The base DN to search from. If not specified, the search will start at the LDAP's root.
 - `binary_attribute_settings` (Attributes Map) The advanced settings for binary LDAP attributes. (see [below for nested schema](#nestedatt--idp_browser_sso--adapter_mappings--attribute_sources--ldap_attribute_source--binary_attribute_settings))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
-- `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `member_of_nested_group` (Boolean) Set this to true to return transitive group memberships for the 'memberOf' attribute.  This only applies for Active Directory data sources.  All other data sources will be set to false.
 - `search_attributes` (Set of String) A list of LDAP attributes returned from search and available for mapping.
 

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
@@ -142,7 +142,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               search_filter          = "(&(memberUid=uid)(cn=Postman))"
               search_scope           = "SUBTREE"
               type                   = "LDAP"
-              id = "myldapattrsource"
+              id                     = "myldapattrsource"
             }
           },
         ]

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_cert_id_test.go
@@ -97,19 +97,16 @@ resource "pingfederate_sp_idp_connection" "example" {
       {
         attribute_sources = [
           {
-            ldap_attribute_source = {
+            jdbc_attribute_source = {
               attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
+              column_names                   = ["GRANTEE"]
               data_store_ref = {
-                id = "pingdirectory"
+                id = "ProvisionerDS"
               }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
+              description = "JDBC"
+              filter      = "subject"
+              schema      = "INFORMATION_SCHEMA"
+              table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
             }
           },
         ]
@@ -145,6 +142,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               search_filter          = "(&(memberUid=uid)(cn=Postman))"
               search_scope           = "SUBTREE"
               type                   = "LDAP"
+              id = "myldapattrsource"
             }
           },
         ]
@@ -209,6 +207,7 @@ resource "pingfederate_sp_idp_connection" "example" {
       attribute_sources = [
         {
           jdbc_attribute_source = {
+            id = "myjdbcsource"
             data_store_ref = {
               id = "ProvisionerDS",
             },

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_oidc_test.go
@@ -392,7 +392,7 @@ resource "pingfederate_sp_idp_connection" "example" {
               }
               description = "JDBC"
               filter      = "subject"
-              id          = null
+              id          = "myjdbcsource"
               schema      = "INFORMATION_SCHEMA"
               table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
             }

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_saml_test.go
@@ -274,21 +274,24 @@ resource "pingfederate_sp_idp_connection" "example" {
     adapter_mappings = [
       {
         attribute_sources = [
-
           {
-            ldap_attribute_source = {
-              attribute_contract_fulfillment = null
-              base_dn                        = "ou=Applications,ou=Ping,ou=Groups,dc=dm,dc=example,dc=com"
-              binary_attribute_settings      = null
+            custom_attribute_source = {
               data_store_ref = {
-                id = "pingdirectory"
+                id = "customDataStore"
               }
-              description            = "PingDirectory"
-              member_of_nested_group = false
-              search_attributes      = ["Subject DN"]
-              search_filter          = "(&(memberUid=uid)(cn=Postman))"
-              search_scope           = "SUBTREE"
-              type                   = "LDAP"
+              description = "APIStubs"
+              filter_fields = [
+                {
+                  name = "Authorization Header"
+                },
+                {
+                  name = "Body"
+                },
+                {
+                  name  = "Resource Path"
+                  value = "/users/extid"
+                },
+              ]
             }
           },
         ]
@@ -598,7 +601,7 @@ resource "pingfederate_sp_idp_connection" "example" {
             }
             description = "JDBC"
             filter      = "$${SAML_SUBJECT}"
-            id          = null
+            id          = "myjdbcsource"
             schema      = "INFORMATION_SCHEMA"
             table       = "ADMINISTRABLE_ROLE_AUTHORIZATIONS"
           }

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_trust_sts_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_ws_trust_sts_test.go
@@ -314,6 +314,7 @@ resource "pingfederate_sp_idp_connection" "example" {
             column_names = [
               "GRANTEE"
             ]
+            id = "myjdbcsource"
           }
         }
       ]

--- a/internal/resource/common/attributesources/attribute_sources_client_struct.go
+++ b/internal/resource/common/attributesources/attribute_sources_client_struct.go
@@ -10,6 +10,14 @@ import (
 )
 
 func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSourceAggregation {
+	return clientStructInternal(attributeSourcesAttr, true)
+}
+
+func ClientStructNoId(attributeSourcesAttr basetypes.SetValue) []client.AttributeSourceAggregation {
+	return clientStructInternal(attributeSourcesAttr, false)
+}
+
+func clientStructInternal(attributeSourcesAttr basetypes.SetValue, includeIdAttr bool) []client.AttributeSourceAggregation {
 	attributeSourceAggregation := []client.AttributeSourceAggregation{}
 	for _, source := range attributeSourcesAttr.Elements() {
 		//Determine which attribute source type this is
@@ -47,7 +55,9 @@ func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSou
 					attributeSourceInner.CustomAttributeSource.FilterFields = append(attributeSourceInner.CustomAttributeSource.FilterFields, filterFieldsValue)
 				}
 			}
-			attributeSourceInner.CustomAttributeSource.Id = customAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			if includeIdAttr {
+				attributeSourceInner.CustomAttributeSource.Id = customAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			}
 			attributeSourceInner.CustomAttributeSource.Type = customAttributeSourceAttrs["type"].(types.String).ValueString()
 		}
 		if internaltypes.IsDefined(sourceAttrs["jdbc_attribute_source"]) {
@@ -79,7 +89,9 @@ func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSou
 			attributeSourceInner.JdbcAttributeSource.DataStoreRef = jdbcAttributeSourceDataStoreRefValue
 			attributeSourceInner.JdbcAttributeSource.Description = jdbcAttributeSourceAttrs["description"].(types.String).ValueStringPointer()
 			attributeSourceInner.JdbcAttributeSource.Filter = jdbcAttributeSourceAttrs["filter"].(types.String).ValueString()
-			attributeSourceInner.JdbcAttributeSource.Id = jdbcAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			if includeIdAttr {
+				attributeSourceInner.JdbcAttributeSource.Id = jdbcAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			}
 			attributeSourceInner.JdbcAttributeSource.Schema = jdbcAttributeSourceAttrs["schema"].(types.String).ValueStringPointer()
 			attributeSourceInner.JdbcAttributeSource.Table = jdbcAttributeSourceAttrs["table"].(types.String).ValueString()
 			attributeSourceInner.JdbcAttributeSource.Type = jdbcAttributeSourceAttrs["type"].(types.String).ValueString()
@@ -116,7 +128,9 @@ func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSou
 			ldapAttributeSourceDataStoreRefValue.Id = ldapAttributeSourceDataStoreRefAttrs["id"].(types.String).ValueString()
 			attributeSourceInner.LdapAttributeSource.DataStoreRef = ldapAttributeSourceDataStoreRefValue
 			attributeSourceInner.LdapAttributeSource.Description = ldapAttributeSourceAttrs["description"].(types.String).ValueStringPointer()
-			attributeSourceInner.LdapAttributeSource.Id = ldapAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			if includeIdAttr {
+				attributeSourceInner.LdapAttributeSource.Id = ldapAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			}
 			attributeSourceInner.LdapAttributeSource.MemberOfNestedGroup = ldapAttributeSourceAttrs["member_of_nested_group"].(types.Bool).ValueBoolPointer()
 			if !ldapAttributeSourceAttrs["search_attributes"].IsNull() && !ldapAttributeSourceAttrs["search_attributes"].IsUnknown() {
 				attributeSourceInner.LdapAttributeSource.SearchAttributes = []string{}

--- a/internal/resource/common/attributesources/attribute_sources_client_struct.go
+++ b/internal/resource/common/attributesources/attribute_sources_client_struct.go
@@ -10,14 +10,6 @@ import (
 )
 
 func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSourceAggregation {
-	return clientStructInternal(attributeSourcesAttr, true)
-}
-
-func ClientStructNoId(attributeSourcesAttr basetypes.SetValue) []client.AttributeSourceAggregation {
-	return clientStructInternal(attributeSourcesAttr, false)
-}
-
-func clientStructInternal(attributeSourcesAttr basetypes.SetValue, includeIdAttr bool) []client.AttributeSourceAggregation {
 	attributeSourceAggregation := []client.AttributeSourceAggregation{}
 	for _, source := range attributeSourcesAttr.Elements() {
 		//Determine which attribute source type this is
@@ -55,8 +47,9 @@ func clientStructInternal(attributeSourcesAttr basetypes.SetValue, includeIdAttr
 					attributeSourceInner.CustomAttributeSource.FilterFields = append(attributeSourceInner.CustomAttributeSource.FilterFields, filterFieldsValue)
 				}
 			}
-			if includeIdAttr {
-				attributeSourceInner.CustomAttributeSource.Id = customAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			idAttr, ok := customAttributeSourceAttrs["id"]
+			if ok {
+				attributeSourceInner.CustomAttributeSource.Id = idAttr.(types.String).ValueStringPointer()
 			}
 			attributeSourceInner.CustomAttributeSource.Type = customAttributeSourceAttrs["type"].(types.String).ValueString()
 		}
@@ -89,8 +82,9 @@ func clientStructInternal(attributeSourcesAttr basetypes.SetValue, includeIdAttr
 			attributeSourceInner.JdbcAttributeSource.DataStoreRef = jdbcAttributeSourceDataStoreRefValue
 			attributeSourceInner.JdbcAttributeSource.Description = jdbcAttributeSourceAttrs["description"].(types.String).ValueStringPointer()
 			attributeSourceInner.JdbcAttributeSource.Filter = jdbcAttributeSourceAttrs["filter"].(types.String).ValueString()
-			if includeIdAttr {
-				attributeSourceInner.JdbcAttributeSource.Id = jdbcAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			idAttr, ok := jdbcAttributeSourceAttrs["id"]
+			if ok {
+				attributeSourceInner.JdbcAttributeSource.Id = idAttr.(types.String).ValueStringPointer()
 			}
 			attributeSourceInner.JdbcAttributeSource.Schema = jdbcAttributeSourceAttrs["schema"].(types.String).ValueStringPointer()
 			attributeSourceInner.JdbcAttributeSource.Table = jdbcAttributeSourceAttrs["table"].(types.String).ValueString()
@@ -128,8 +122,9 @@ func clientStructInternal(attributeSourcesAttr basetypes.SetValue, includeIdAttr
 			ldapAttributeSourceDataStoreRefValue.Id = ldapAttributeSourceDataStoreRefAttrs["id"].(types.String).ValueString()
 			attributeSourceInner.LdapAttributeSource.DataStoreRef = ldapAttributeSourceDataStoreRefValue
 			attributeSourceInner.LdapAttributeSource.Description = ldapAttributeSourceAttrs["description"].(types.String).ValueStringPointer()
-			if includeIdAttr {
-				attributeSourceInner.LdapAttributeSource.Id = ldapAttributeSourceAttrs["id"].(types.String).ValueStringPointer()
+			idAttr, ok := ldapAttributeSourceAttrs["id"]
+			if ok {
+				attributeSourceInner.LdapAttributeSource.Id = idAttr.(types.String).ValueStringPointer()
 			}
 			attributeSourceInner.LdapAttributeSource.MemberOfNestedGroup = ldapAttributeSourceAttrs["member_of_nested_group"].(types.Bool).ValueBoolPointer()
 			if !ldapAttributeSourceAttrs["search_attributes"].IsNull() && !ldapAttributeSourceAttrs["search_attributes"].IsUnknown() {

--- a/internal/resource/common/attributesources/attribute_sources_schema.go
+++ b/internal/resource/common/attributesources/attribute_sources_schema.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -180,13 +179,7 @@ func ToSchemaNoIdAttr() schema.SetNestedAttribute {
 }
 
 func toSchemaInternal(sizeAtLeast int, optionalAndComputedNestedAttributeContractFulfillment, includeValueDefault, includeIdAttr bool) schema.SetNestedAttribute {
-	var attrTypes map[string]attr.Type
-	if includeIdAttr {
-		attrTypes = AttrTypes()
-	} else {
-		attrTypes = AttrTypesNoId()
-	}
-	attributeSourcesDefault, _ := types.SetValue(types.ObjectType{AttrTypes: attrTypes}, nil)
+	attributeSourcesDefault, _ := types.SetValue(types.ObjectType{AttrTypes: attrTypesInternal(includeIdAttr)}, nil)
 	validators := []validator.Set{}
 	if sizeAtLeast > 0 {
 		validators = append(validators, setvalidator.SizeAtLeast(sizeAtLeast))

--- a/internal/resource/common/attributesources/attribute_sources_state.go
+++ b/internal/resource/common/attributesources/attribute_sources_state.go
@@ -14,18 +14,20 @@ import (
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/resourcelink"
 )
 
-func CommonAttributeSourceAttrType() map[string]attr.Type {
+func commonAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
 	commonAttrSourceAttrType := map[string]attr.Type{}
 	commonAttrSourceAttrType["type"] = types.StringType
 	commonAttrSourceAttrType["data_store_ref"] = types.ObjectType{AttrTypes: resourcelink.AttrType()}
-	commonAttrSourceAttrType["id"] = types.StringType
+	if includeIdAttr {
+		commonAttrSourceAttrType["id"] = types.StringType
+	}
 	commonAttrSourceAttrType["description"] = types.StringType
 	commonAttrSourceAttrType["attribute_contract_fulfillment"] = attributecontractfulfillment.MapType()
 	return commonAttrSourceAttrType
 }
 
-func CustomAttributeSourceAttrType() map[string]attr.Type {
-	customAttrSourceAttrType := CommonAttributeSourceAttrType()
+func customAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
+	customAttrSourceAttrType := commonAttributeSourceAttrType(includeIdAttr)
 	customAttrSourceAttrType["filter_fields"] = types.SetType{ElemType: types.ObjectType{
 		AttrTypes: map[string]attr.Type{
 			"value": types.StringType,
@@ -35,8 +37,8 @@ func CustomAttributeSourceAttrType() map[string]attr.Type {
 	return customAttrSourceAttrType
 }
 
-func JdbcAttributeSourceAttrType() map[string]attr.Type {
-	jdbcAttributeSourceAttrType := CommonAttributeSourceAttrType()
+func jdbcAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
+	jdbcAttributeSourceAttrType := commonAttributeSourceAttrType(includeIdAttr)
 	jdbcAttributeSourceAttrType["schema"] = types.StringType
 	jdbcAttributeSourceAttrType["table"] = types.StringType
 	jdbcAttributeSourceAttrType["column_names"] = types.ListType{ElemType: types.StringType}
@@ -44,8 +46,8 @@ func JdbcAttributeSourceAttrType() map[string]attr.Type {
 	return jdbcAttributeSourceAttrType
 }
 
-func LdapAttributeSourceAttrType() map[string]attr.Type {
-	ldapAttrSourceAttrType := CommonAttributeSourceAttrType()
+func ldapAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
+	ldapAttrSourceAttrType := commonAttributeSourceAttrType(includeIdAttr)
 	ldapAttrSourceAttrType["base_dn"] = types.StringType
 	ldapAttrSourceAttrType["search_scope"] = types.StringType
 	ldapAttrSourceAttrType["search_filter"] = types.StringType
@@ -64,22 +66,50 @@ func LdapAttributeSourceAttrType() map[string]attr.Type {
 func AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"custom_attribute_source": types.ObjectType{
-			AttrTypes: CustomAttributeSourceAttrType(),
+			AttrTypes: customAttributeSourceAttrType(true),
 		},
 		"jdbc_attribute_source": types.ObjectType{
-			AttrTypes: JdbcAttributeSourceAttrType(),
+			AttrTypes: jdbcAttributeSourceAttrType(true),
 		},
 		"ldap_attribute_source": types.ObjectType{
-			AttrTypes: LdapAttributeSourceAttrType(),
+			AttrTypes: ldapAttributeSourceAttrType(true),
+		},
+	}
+}
+
+func AttrTypesNoId() map[string]attr.Type {
+	return map[string]attr.Type{
+		"custom_attribute_source": types.ObjectType{
+			AttrTypes: customAttributeSourceAttrType(false),
+		},
+		"jdbc_attribute_source": types.ObjectType{
+			AttrTypes: jdbcAttributeSourceAttrType(false),
+		},
+		"ldap_attribute_source": types.ObjectType{
+			AttrTypes: ldapAttributeSourceAttrType(false),
 		},
 	}
 }
 
 func ToState(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation) (basetypes.SetValue, diag.Diagnostics) {
+	return toStateInternal(con, attributeSourcesFromClient, true)
+}
+
+func ToStateNoId(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation) (basetypes.SetValue, diag.Diagnostics) {
+	return toStateInternal(con, attributeSourcesFromClient, false)
+}
+
+func toStateInternal(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation, includeIdAttr bool) (basetypes.SetValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var customAttrSourceAttrTypes = CustomAttributeSourceAttrType()
-	var jdbcAttrSourceAttrTypes = JdbcAttributeSourceAttrType()
-	var ldapAttrSourceAttrTypes = LdapAttributeSourceAttrType()
+	var customAttrSourceAttrTypes = customAttributeSourceAttrType(includeIdAttr)
+	var jdbcAttrSourceAttrTypes = jdbcAttributeSourceAttrType(includeIdAttr)
+	var ldapAttrSourceAttrTypes = ldapAttributeSourceAttrType(includeIdAttr)
+	var attrTypes map[string]attr.Type
+	if includeIdAttr {
+		attrTypes = AttrTypes()
+	} else {
+		attrTypes = AttrTypesNoId()
+	}
 	var valueFromDiags diag.Diagnostics
 
 	// Build attribute_sources value
@@ -95,7 +125,9 @@ func ToState(con context.Context, attributeSourcesFromClient []client.AttributeS
 			customAttrSourceValues["type"] = types.StringValue("CUSTOM")
 			customAttrSourceValues["data_store_ref"], valueFromDiags = types.ObjectValueFrom(con, resourcelink.AttrType(), attrSource.CustomAttributeSource.DataStoreRef)
 			diags.Append(valueFromDiags...)
-			customAttrSourceValues["id"] = types.StringPointerValue(attrSource.CustomAttributeSource.Id)
+			if includeIdAttr {
+				customAttrSourceValues["id"] = types.StringPointerValue(attrSource.CustomAttributeSource.Id)
+			}
 			customAttrSourceValues["description"] = types.StringPointerValue(attrSource.CustomAttributeSource.Description)
 			customAttrSourceValues["attribute_contract_fulfillment"], valueFromDiags = types.MapValueFrom(con, types.ObjectType{AttrTypes: attributecontractfulfillment.AttrTypes()}, attrSource.CustomAttributeSource.AttributeContractFulfillment)
 			diags.Append(valueFromDiags...)
@@ -114,7 +146,9 @@ func ToState(con context.Context, attributeSourcesFromClient []client.AttributeS
 			jdbcAttrSourceValues["type"] = types.StringValue("JDBC")
 			jdbcAttrSourceValues["data_store_ref"], valueFromDiags = types.ObjectValueFrom(con, resourcelink.AttrType(), attrSource.JdbcAttributeSource.DataStoreRef)
 			diags.Append(valueFromDiags...)
-			jdbcAttrSourceValues["id"] = types.StringPointerValue(attrSource.JdbcAttributeSource.Id)
+			if includeIdAttr {
+				jdbcAttrSourceValues["id"] = types.StringPointerValue(attrSource.JdbcAttributeSource.Id)
+			}
 			jdbcAttrSourceValues["description"] = types.StringPointerValue(attrSource.JdbcAttributeSource.Description)
 			jdbcAttrSourceValues["attribute_contract_fulfillment"], valueFromDiags = types.MapValueFrom(con, types.ObjectType{AttrTypes: attributecontractfulfillment.AttrTypes()}, attrSource.JdbcAttributeSource.AttributeContractFulfillment)
 			diags.Append(valueFromDiags...)
@@ -140,7 +174,9 @@ func ToState(con context.Context, attributeSourcesFromClient []client.AttributeS
 			ldapAttrSourceValues["type"] = types.StringValue(attrSource.LdapAttributeSource.Type)
 			ldapAttrSourceValues["data_store_ref"], valueFromDiags = types.ObjectValueFrom(con, resourcelink.AttrType(), attrSource.LdapAttributeSource.DataStoreRef)
 			diags.Append(valueFromDiags...)
-			ldapAttrSourceValues["id"] = types.StringPointerValue(attrSource.LdapAttributeSource.Id)
+			if includeIdAttr {
+				ldapAttrSourceValues["id"] = types.StringPointerValue(attrSource.LdapAttributeSource.Id)
+			}
 			ldapAttrSourceValues["description"] = types.StringPointerValue(attrSource.LdapAttributeSource.Description)
 			ldapAttrSourceValues["attribute_contract_fulfillment"], valueFromDiags = types.MapValueFrom(con, types.ObjectType{AttrTypes: attributecontractfulfillment.AttrTypes()}, attrSource.LdapAttributeSource.AttributeContractFulfillment)
 			diags.Append(valueFromDiags...)
@@ -149,11 +185,11 @@ func ToState(con context.Context, attributeSourcesFromClient []client.AttributeS
 		} else {
 			attrSourceValues["ldap_attribute_source"] = types.ObjectNull(ldapAttrSourceAttrTypes)
 		}
-		attrSourceElement, valueFromDiags := types.ObjectValue(AttrTypes(), attrSourceValues)
+		attrSourceElement, valueFromDiags := types.ObjectValue(attrTypes, attrSourceValues)
 		diags.Append(valueFromDiags...)
 		attrSourceElements = append(attrSourceElements, attrSourceElement)
 	}
-	attrToState, valueFromDiags := types.SetValue(types.ObjectType{AttrTypes: AttrTypes()}, attrSourceElements)
+	attrToState, valueFromDiags := types.SetValue(types.ObjectType{AttrTypes: attrTypes}, attrSourceElements)
 	diags.Append(valueFromDiags...)
 	return attrToState, diags
 }

--- a/internal/resource/common/attributesources/attribute_sources_state.go
+++ b/internal/resource/common/attributesources/attribute_sources_state.go
@@ -64,29 +64,23 @@ func ldapAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
 }
 
 func AttrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"custom_attribute_source": types.ObjectType{
-			AttrTypes: customAttributeSourceAttrType(true),
-		},
-		"jdbc_attribute_source": types.ObjectType{
-			AttrTypes: jdbcAttributeSourceAttrType(true),
-		},
-		"ldap_attribute_source": types.ObjectType{
-			AttrTypes: ldapAttributeSourceAttrType(true),
-		},
-	}
+	return attrTypesInternal(true)
 }
 
 func AttrTypesNoId() map[string]attr.Type {
+	return attrTypesInternal(false)
+}
+
+func attrTypesInternal(includeIdAttr bool) map[string]attr.Type {
 	return map[string]attr.Type{
 		"custom_attribute_source": types.ObjectType{
-			AttrTypes: customAttributeSourceAttrType(false),
+			AttrTypes: customAttributeSourceAttrType(includeIdAttr),
 		},
 		"jdbc_attribute_source": types.ObjectType{
-			AttrTypes: jdbcAttributeSourceAttrType(false),
+			AttrTypes: jdbcAttributeSourceAttrType(includeIdAttr),
 		},
 		"ldap_attribute_source": types.ObjectType{
-			AttrTypes: ldapAttributeSourceAttrType(false),
+			AttrTypes: ldapAttributeSourceAttrType(includeIdAttr),
 		},
 	}
 }
@@ -104,12 +98,6 @@ func toStateInternal(con context.Context, attributeSourcesFromClient []client.At
 	var customAttrSourceAttrTypes = customAttributeSourceAttrType(includeIdAttr)
 	var jdbcAttrSourceAttrTypes = jdbcAttributeSourceAttrType(includeIdAttr)
 	var ldapAttrSourceAttrTypes = ldapAttributeSourceAttrType(includeIdAttr)
-	var attrTypes map[string]attr.Type
-	if includeIdAttr {
-		attrTypes = AttrTypes()
-	} else {
-		attrTypes = AttrTypesNoId()
-	}
 	var valueFromDiags diag.Diagnostics
 
 	// Build attribute_sources value
@@ -185,11 +173,11 @@ func toStateInternal(con context.Context, attributeSourcesFromClient []client.At
 		} else {
 			attrSourceValues["ldap_attribute_source"] = types.ObjectNull(ldapAttrSourceAttrTypes)
 		}
-		attrSourceElement, valueFromDiags := types.ObjectValue(attrTypes, attrSourceValues)
+		attrSourceElement, valueFromDiags := types.ObjectValue(attrTypesInternal(includeIdAttr), attrSourceValues)
 		diags.Append(valueFromDiags...)
 		attrSourceElements = append(attrSourceElements, attrSourceElement)
 	}
-	attrToState, valueFromDiags := types.SetValue(types.ObjectType{AttrTypes: attrTypes}, attrSourceElements)
+	attrToState, valueFromDiags := types.SetValue(types.ObjectType{AttrTypes: attrTypesInternal(includeIdAttr)}, attrSourceElements)
 	diags.Append(valueFromDiags...)
 	return attrToState, diags
 }

--- a/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
+++ b/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
@@ -170,7 +170,7 @@ var (
 	idpBrowserSsoAdapterMappingsAttrTypes = map[string]attr.Type{
 		"adapter_override_settings":      types.ObjectType{AttrTypes: idpBrowserSsoAdapterMappingsAdapterOverrideSettingsAttrTypes},
 		"attribute_contract_fulfillment": attributecontractfulfillment.MapType(),
-		"attribute_sources":              types.SetType{ElemType: types.ObjectType{AttrTypes: attributesources.AttrTypes()}},
+		"attribute_sources":              types.SetType{ElemType: types.ObjectType{AttrTypes: attributesources.AttrTypesNoId()}},
 		"issuance_criteria":              types.ObjectType{AttrTypes: issuancecriteria.AttrTypes()},
 		"restrict_virtual_entity_ids":    types.BoolType,
 		"restricted_virtual_entity_ids":  types.SetType{ElemType: types.StringType},
@@ -617,6 +617,10 @@ type spIdpConnectionResourceModel struct {
 
 // GetSchema defines the schema for the resource.
 func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	adapterMappingsAttrSources := attributesources.ToSchemaNoIdAttr()
+	adapterMappingsAttrSources.Validators = []validator.Set{
+		setvalidator.SizeAtMost(1),
+	}
 	schema := schema.Schema{
 		Description: "Manages a partner Identity Provider connection",
 		Attributes: map[string]schema.Attribute{
@@ -1191,7 +1195,7 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 									},
 								},
 								"attribute_contract_fulfillment": attributecontractfulfillment.ToSchema(true, false, false),
-								"attribute_sources":              attributesources.ToSchema(0, false),
+								"attribute_sources":              adapterMappingsAttrSources,
 								"issuance_criteria":              issuancecriteria.ToSchema(),
 								"restrict_virtual_entity_ids": schema.BoolAttribute{
 									Optional:            true,
@@ -3840,7 +3844,7 @@ func addOptionalSpIdpConnectionFields(ctx context.Context, addRequest *client.Id
 				adapterMappingsValue.AdapterOverrideSettings = adapterMappingsAdapterOverrideSettingsValue
 			}
 			adapterMappingsValue.AttributeContractFulfillment = attributecontractfulfillment.ClientStruct(adapterMappingsAttrs["attribute_contract_fulfillment"].(types.Map))
-			adapterMappingsValue.AttributeSources = attributesources.ClientStruct(adapterMappingsAttrs["attribute_sources"].(types.Set))
+			adapterMappingsValue.AttributeSources = attributesources.ClientStructNoId(adapterMappingsAttrs["attribute_sources"].(types.Set))
 			adapterMappingsValue.IssuanceCriteria = issuancecriteria.ClientStruct(adapterMappingsAttrs["issuance_criteria"].(types.Object))
 			adapterMappingsValue.RestrictVirtualEntityIds = adapterMappingsAttrs["restrict_virtual_entity_ids"].(types.Bool).ValueBoolPointer()
 			if !adapterMappingsAttrs["restricted_virtual_entity_ids"].IsNull() {
@@ -4847,7 +4851,7 @@ func readSpIdpConnectionResponse(ctx context.Context, r *client.IdpConnection, p
 				idpBrowserSsoAdapterMappingsAttributeContractFulfillmentValue, objDiags := attributecontractfulfillment.ToState(ctx, &idpBrowserSsoAdapterMappingsResponseValueAttributeContractFulfillment)
 				respDiags.Append(objDiags...)
 
-				idpBrowserSsoAdapterMappingsAttributeSourcesValue, objDiags := attributesources.ToState(ctx, idpBrowserSsoAdapterMappingsResponseValue.AttributeSources)
+				idpBrowserSsoAdapterMappingsAttributeSourcesValue, objDiags := attributesources.ToStateNoId(ctx, idpBrowserSsoAdapterMappingsResponseValue.AttributeSources)
 				respDiags.Append(objDiags...)
 
 				var idpBrowserSsoAdapterMappingsIssuanceCriteriaValue types.Object

--- a/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
+++ b/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
@@ -3844,7 +3844,7 @@ func addOptionalSpIdpConnectionFields(ctx context.Context, addRequest *client.Id
 				adapterMappingsValue.AdapterOverrideSettings = adapterMappingsAdapterOverrideSettingsValue
 			}
 			adapterMappingsValue.AttributeContractFulfillment = attributecontractfulfillment.ClientStruct(adapterMappingsAttrs["attribute_contract_fulfillment"].(types.Map))
-			adapterMappingsValue.AttributeSources = attributesources.ClientStructNoId(adapterMappingsAttrs["attribute_sources"].(types.Set))
+			adapterMappingsValue.AttributeSources = attributesources.ClientStruct(adapterMappingsAttrs["attribute_sources"].(types.Set))
 			adapterMappingsValue.IssuanceCriteria = issuancecriteria.ClientStruct(adapterMappingsAttrs["issuance_criteria"].(types.Object))
 			adapterMappingsValue.RestrictVirtualEntityIds = adapterMappingsAttrs["restrict_virtual_entity_ids"].(types.Bool).ValueBoolPointer()
 			if !adapterMappingsAttrs["restricted_virtual_entity_ids"].IsNull() {


### PR DESCRIPTION
Fixed validation for the `idp_browser_sso.adapter_mappings.attribute_sources` attribute in the `pingfederate_sp_idp_connection` resource. The attribute sources are now limited to a maximum size of `1`, and the `id` attribute for the individual attribute sources is removed, as it is not supported in IdP connection adapter mappings.