### PR TITLE
Add timestamp nil checks to prevent potential panics for resources originally created in older PingFederate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 * Fixed the required `file_data` field not being written to state on import for the `pingfederate_certificate_ca`, `pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate`, and `pingfederate_metadata_url` resources. ([#502](https://github.com/pingidentity/terraform-provider-pingfederate/pull/502))
 * Fixed validation for the `idp_browser_sso.adapter_mappings.attribute_sources` attribute in the `pingfederate_sp_idp_connection` resource. The attribute sources are now limited to a maximum size of `1`, and the `id` attribute for the individual attribute sources is removed, as it is not supported in IdP connection adapter mappings. ([#503](https://github.com/pingidentity/terraform-provider-pingfederate/pull/503))
+* Fix potential panic due to missing creation timestamp values in `pingfederate_idp_sp_connection`. ([#509](https://github.com/pingidentity/terraform-provider-pingfederate/pull/509))
 
 # v1.4.5 April 30, 2025
 ### Bug fixes

--- a/internal/resource/config/certificates/ca/certificate_ca_data_source.go
+++ b/internal/resource/config/certificates/ca/certificate_ca_data_source.go
@@ -173,8 +173,16 @@ func readCertificateResponseDataSource(ctx context.Context, r *client.CertView, 
 	state.SubjectDN = types.StringPointerValue(r.SubjectDN)
 	state.SubjectAlternativeNames = internaltypes.GetStringSet(r.SubjectAlternativeNames)
 	state.IssuerDN = types.StringPointerValue(r.IssuerDN)
-	state.ValidFrom = types.StringValue(r.ValidFrom.Format(time.RFC3339))
-	state.Expires = types.StringValue(r.Expires.Format(time.RFC3339))
+	if r.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(r.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
+	if r.Expires != nil {
+		state.Expires = types.StringValue(r.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	state.KeyAlgorithm = types.StringPointerValue(r.KeyAlgorithm)
 	state.KeySize = types.Int64PointerValue(r.KeySize)
 	state.SignatureAlgorithm = types.StringPointerValue(r.SignatureAlgorithm)

--- a/internal/resource/config/certificates/ca/certificate_ca_resource.go
+++ b/internal/resource/config/certificates/ca/certificate_ca_resource.go
@@ -227,8 +227,16 @@ func (state *certificatesResourceModel) readCertificateResponse(r *client.CertVi
 	state.SubjectDn = types.StringPointerValue(r.SubjectDN)
 	state.SubjectAlternativeNames = internaltypes.GetStringSet(r.SubjectAlternativeNames)
 	state.IssuerDn = types.StringPointerValue(r.IssuerDN)
-	state.ValidFrom = types.StringValue(r.ValidFrom.Format(time.RFC3339))
-	state.Expires = types.StringValue(r.Expires.Format(time.RFC3339))
+	if r.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(r.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
+	if r.Expires != nil {
+		state.Expires = types.StringValue(r.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	state.KeyAlgorithm = types.StringPointerValue(r.KeyAlgorithm)
 	state.KeySize = types.Int64PointerValue(r.KeySize)
 	state.SignatureAlgorithm = types.StringPointerValue(r.SignatureAlgorithm)

--- a/internal/resource/config/certificates/groups/certificates_group_resource_gen.go
+++ b/internal/resource/config/certificates/groups/certificates_group_resource_gen.go
@@ -204,7 +204,11 @@ func (state *certificatesGroupResourceModel) readClientResponse(response *client
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// group_id
 	state.GroupId = types.StringPointerValue(response.Id)
 	// issuer_dn
@@ -229,7 +233,11 @@ func (state *certificatesGroupResourceModel) readClientResponse(response *client
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.SubjectDN)
 	// valid_from
-	state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	if response.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
 	// version
 	state.Version = types.Int64PointerValue(response.Version)
 	return respDiags

--- a/internal/resource/config/certificates/revocation/ocspcertificates/certificates_revocation_ocsp_certificate_resource_gen.go
+++ b/internal/resource/config/certificates/revocation/ocspcertificates/certificates_revocation_ocsp_certificate_resource_gen.go
@@ -193,7 +193,11 @@ func (state *certificatesRevocationOcspCertificateResourceModel) readClientRespo
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm
@@ -216,7 +220,11 @@ func (state *certificatesRevocationOcspCertificateResourceModel) readClientRespo
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.SubjectDN)
 	// valid_from
-	state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	if response.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
 	// version
 	state.Version = types.Int64PointerValue(response.Version)
 	return respDiags

--- a/internal/resource/config/idp/spconnection/idp_sp_connection_data_source.go
+++ b/internal/resource/config/idp/spconnection/idp_sp_connection_data_source.go
@@ -1453,7 +1453,11 @@ func readIdpSpconnectionDataSourceResponse(ctx context.Context, r *client.SpConn
 
 	state.ContactInfo = contactInfoValue
 	// creation_date
-	state.CreationDate = types.StringValue(r.CreationDate.Format(time.RFC3339))
+	if r.CreationDate != nil {
+		state.CreationDate = types.StringValue(r.CreationDate.Format(time.RFC3339))
+	} else {
+		state.CreationDate = types.StringNull()
+	}
 	// credentials
 	var credentialsCertsValues []attr.Value
 	for _, cert := range r.Credentials.Certs {

--- a/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
+++ b/internal/resource/config/idp/spconnection/idp_sp_connection_resource.go
@@ -2792,7 +2792,11 @@ func (state *idpSpConnectionModel) readClientResponse(response *client.SpConnect
 
 	state.ContactInfo = contactInfoValue
 	// creation_date
-	state.CreationDate = types.StringValue(response.CreationDate.Format(time.RFC3339))
+	if response.CreationDate != nil {
+		state.CreationDate = types.StringValue(response.CreationDate.Format(time.RFC3339))
+	} else {
+		state.CreationDate = types.StringNull()
+	}
 	// credentials
 	var credentialsValue types.Object
 	if response.Credentials != nil {

--- a/internal/resource/config/keypairs/signing/keypairs_signing_key_data_source.go
+++ b/internal/resource/config/keypairs/signing/keypairs_signing_key_data_source.go
@@ -166,7 +166,11 @@ func (state *keypairsSigningKeyDataSourceModel) readClientResponse(response *cli
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/keypairs/signing/keypairs_signing_key_resource.go
+++ b/internal/resource/config/keypairs/signing/keypairs_signing_key_resource.go
@@ -512,7 +512,11 @@ func (state *keypairsSigningKeyResourceModel) readClientResponse(response *clien
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/keypairs/sslclient/csr/keypairs_ssl_client_csr_resource.go
+++ b/internal/resource/config/keypairs/sslclient/csr/keypairs_ssl_client_csr_resource.go
@@ -175,7 +175,11 @@ func (state *keypairsSslClientCsrResourceModel) readClientResponse(response *cli
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// keypair_id
 	state.KeypairId = types.StringPointerValue(response.Id)
 	// issuer_dn
@@ -200,7 +204,11 @@ func (state *keypairsSslClientCsrResourceModel) readClientResponse(response *cli
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.SubjectDN)
 	// valid_from
-	state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	if response.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
 	// version
 	state.Version = types.Int64PointerValue(response.Version)
 	return respDiags

--- a/internal/resource/config/keypairs/sslclient/keypairs_ssl_client_key_data_source.go
+++ b/internal/resource/config/keypairs/sslclient/keypairs_ssl_client_key_data_source.go
@@ -130,7 +130,11 @@ func (state *keypairsSslClientKeyDataSourceModel) readClientResponse(response *c
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/keypairs/sslclient/keypairs_ssl_client_key_resource.go
+++ b/internal/resource/config/keypairs/sslclient/keypairs_ssl_client_key_resource.go
@@ -476,7 +476,11 @@ func (state *keypairsSslClientKeyResourceModel) readClientResponse(response *cli
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/keypairs/sslserver/csr/keypairs_ssl_server_csr_response_resource.go
+++ b/internal/resource/config/keypairs/sslserver/csr/keypairs_ssl_server_csr_response_resource.go
@@ -175,7 +175,11 @@ func (state *keypairsSslServerCsrResourceModel) readClientResponse(response *cli
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// keypair_id
 	state.KeypairId = types.StringPointerValue(response.Id)
 	// issuer_dn
@@ -200,7 +204,11 @@ func (state *keypairsSslServerCsrResourceModel) readClientResponse(response *cli
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.SubjectDN)
 	// valid_from
-	state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	if response.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(response.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
 	// version
 	state.Version = types.Int64PointerValue(response.Version)
 	return respDiags

--- a/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_data_source.go
+++ b/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_data_source.go
@@ -130,7 +130,11 @@ func (state *keypairsSslServerKeyDataSourceModel) readClientResponse(response *c
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_resource.go
+++ b/internal/resource/config/keypairs/sslserver/keypairs_ssl_server_key_resource.go
@@ -512,7 +512,11 @@ func (state *keypairsSslServerKeyResourceModel) readClientResponse(response *cli
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	if response.Expires != nil {
+		state.Expires = types.StringValue(response.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// issuer_dn
 	state.IssuerDn = types.StringPointerValue(response.IssuerDN)
 	// key_algorithm

--- a/internal/resource/config/license/license_data_source.go
+++ b/internal/resource/config/license/license_data_source.go
@@ -238,8 +238,16 @@ func readLicenseResponseDataSource(ctx context.Context, r *client.LicenseView, s
 	state.MaxConnections = types.Int64PointerValue(r.MaxConnections)
 	state.UsedConnections = types.Int64PointerValue(r.UsedConnections)
 	state.Tier = types.StringPointerValue(r.Tier)
-	state.IssueDate = types.StringValue(r.IssueDate.Format(time.RFC3339))
-	state.ExpirationDate = types.StringValue(r.ExpirationDate.Format(time.RFC3339))
+	if r.IssueDate != nil {
+		state.IssueDate = types.StringValue(r.IssueDate.Format(time.RFC3339))
+	} else {
+		state.IssueDate = types.StringNull()
+	}
+	if r.ExpirationDate != nil {
+		state.ExpirationDate = types.StringValue(r.ExpirationDate.Format(time.RFC3339))
+	} else {
+		state.ExpirationDate = types.StringNull()
+	}
 	state.EnforcementType = types.StringPointerValue(r.EnforcementType)
 	state.Version = types.StringPointerValue(r.Version)
 	state.Product = types.StringPointerValue(r.Product)

--- a/internal/resource/config/license/license_resource.go
+++ b/internal/resource/config/license/license_resource.go
@@ -221,8 +221,16 @@ func readLicenseResponse(ctx context.Context, r *client.LicenseView, state *lice
 	state.MaxConnections = types.Int64PointerValue(r.MaxConnections)
 	state.UsedConnections = types.Int64PointerValue(r.UsedConnections)
 	state.Tier = types.StringPointerValue(r.Tier)
-	state.IssueDate = types.StringValue(r.IssueDate.Format(time.RFC3339))
-	state.ExpirationDate = types.StringValue(r.ExpirationDate.Format(time.RFC3339))
+	if r.IssueDate != nil {
+		state.IssueDate = types.StringValue(r.IssueDate.Format(time.RFC3339))
+	} else {
+		state.IssueDate = types.StringNull()
+	}
+	if r.ExpirationDate != nil {
+		state.ExpirationDate = types.StringValue(r.ExpirationDate.Format(time.RFC3339))
+	} else {
+		state.ExpirationDate = types.StringNull()
+	}
 	state.EnforcementType = types.StringPointerValue(r.EnforcementType)
 	state.Version = types.StringPointerValue(r.Version)
 	state.Product = types.StringPointerValue(r.Product)

--- a/internal/resource/config/metadataurls/metadata_url_resource_gen.go
+++ b/internal/resource/config/metadataurls/metadata_url_resource_gen.go
@@ -273,9 +273,21 @@ func (state *metadataUrlResourceModel) readClientResponse(response *client.Metad
 	} else {
 		certViewSubjectAlternativeNamesValue, diags := types.ListValueFrom(context.Background(), types.StringType, response.CertView.SubjectAlternativeNames)
 		respDiags.Append(diags...)
+		var expires types.String
+		if response.CertView.Expires != nil {
+			expires = types.StringValue(response.CertView.Expires.Format(time.RFC3339))
+		} else {
+			expires = types.StringNull()
+		}
+		var validFrom types.String
+		if response.CertView.ValidFrom != nil {
+			validFrom = types.StringValue(response.CertView.ValidFrom.Format(time.RFC3339))
+		} else {
+			validFrom = types.StringNull()
+		}
 		certViewValue, diags = types.ObjectValue(certViewAttrTypes, map[string]attr.Value{
 			"crypto_provider":           types.StringPointerValue(response.CertView.CryptoProvider),
-			"expires":                   types.StringValue(response.CertView.Expires.Format(time.RFC3339)),
+			"expires":                   expires,
 			"id":                        types.StringPointerValue(response.CertView.Id),
 			"issuer_dn":                 types.StringPointerValue(response.CertView.IssuerDN),
 			"key_algorithm":             types.StringPointerValue(response.CertView.KeyAlgorithm),
@@ -287,7 +299,7 @@ func (state *metadataUrlResourceModel) readClientResponse(response *client.Metad
 			"status":                    types.StringPointerValue(response.CertView.Status),
 			"subject_alternative_names": certViewSubjectAlternativeNamesValue,
 			"subject_dn":                types.StringPointerValue(response.CertView.SubjectDN),
-			"valid_from":                types.StringValue(response.CertView.ValidFrom.Format(time.RFC3339)),
+			"valid_from":                validFrom,
 			"version":                   types.Int64PointerValue(response.CertView.Version),
 		})
 		respDiags.Append(diags...)

--- a/internal/resource/config/oauth/client/oauth_client_common.go
+++ b/internal/resource/config/oauth/client/oauth_client_common.go
@@ -270,6 +270,7 @@ func readOauthClientResponseCommon(ctx context.Context, r *client.Client, state,
 	state.RefreshTokenRollingGracePeriodType = types.StringPointerValue(r.RefreshTokenRollingGracePeriodType)
 	state.RefreshTokenRollingGracePeriod = types.Int64PointerValue(r.RefreshTokenRollingGracePeriod)
 	state.ClientSecretRetentionPeriodType = types.StringPointerValue(r.ClientSecretRetentionPeriodType)
+	state.ClientSecretRetentionPeriod = types.Int64PointerValue(r.ClientSecretRetentionPeriod)
 	state.ClientSecretChangedTime = types.StringValue(r.GetClientSecretChangedTime().Format(time.RFC3339Nano))
 	state.TokenIntrospectionSigningAlgorithm = types.StringPointerValue(r.TokenIntrospectionSigningAlgorithm)
 	state.TokenIntrospectionEncryptionAlgorithm = types.StringPointerValue(r.TokenIntrospectionEncryptionAlgorithm)

--- a/internal/resource/config/oauth/client/oauth_client_common.go
+++ b/internal/resource/config/oauth/client/oauth_client_common.go
@@ -183,8 +183,16 @@ func readOauthClientResponseCommon(ctx context.Context, r *client.Client, state,
 	} else {
 		state.Description = types.StringPointerValue(description)
 	}
-	state.ModificationDate = types.StringValue(r.ModificationDate.Format(time.RFC3339Nano))
-	state.CreationDate = types.StringValue(r.CreationDate.Format(time.RFC3339Nano))
+	if r.ModificationDate != nil {
+		state.ModificationDate = types.StringValue(r.ModificationDate.Format(time.RFC3339Nano))
+	} else {
+		state.ModificationDate = types.StringNull()
+	}
+	if r.CreationDate != nil {
+		state.CreationDate = types.StringValue(r.CreationDate.Format(time.RFC3339Nano))
+	} else {
+		state.CreationDate = types.StringNull()
+	}
 	state.LogoUrl = types.StringPointerValue(r.LogoUrl)
 	state.DefaultAccessTokenManagerRef, respDiags = resourcelink.ToState(ctx, r.DefaultAccessTokenManagerRef)
 	diags.Append(respDiags...)
@@ -263,7 +271,11 @@ func readOauthClientResponseCommon(ctx context.Context, r *client.Client, state,
 	state.RefreshTokenRollingGracePeriod = types.Int64PointerValue(r.RefreshTokenRollingGracePeriod)
 	state.ClientSecretRetentionPeriodType = types.StringPointerValue(r.ClientSecretRetentionPeriodType)
 	state.ClientSecretRetentionPeriod = types.Int64PointerValue(r.ClientSecretRetentionPeriod)
-	state.ClientSecretChangedTime = types.StringValue(r.GetClientSecretChangedTime().Format(time.RFC3339Nano))
+	if r.ClientSecretChangedTime != nil {
+		state.ClientSecretChangedTime = types.StringValue(r.ClientSecretChangedTime.Format(time.RFC3339Nano))
+	} else {
+		state.ClientSecretChangedTime = types.StringNull()
+	}
 	state.TokenIntrospectionSigningAlgorithm = types.StringPointerValue(r.TokenIntrospectionSigningAlgorithm)
 	state.TokenIntrospectionEncryptionAlgorithm = types.StringPointerValue(r.TokenIntrospectionEncryptionAlgorithm)
 	state.TokenIntrospectionContentEncryptionAlgorithm = types.StringPointerValue(r.TokenIntrospectionContentEncryptionAlgorithm)

--- a/internal/resource/config/oauth/client/oauth_client_common.go
+++ b/internal/resource/config/oauth/client/oauth_client_common.go
@@ -270,12 +270,7 @@ func readOauthClientResponseCommon(ctx context.Context, r *client.Client, state,
 	state.RefreshTokenRollingGracePeriodType = types.StringPointerValue(r.RefreshTokenRollingGracePeriodType)
 	state.RefreshTokenRollingGracePeriod = types.Int64PointerValue(r.RefreshTokenRollingGracePeriod)
 	state.ClientSecretRetentionPeriodType = types.StringPointerValue(r.ClientSecretRetentionPeriodType)
-	state.ClientSecretRetentionPeriod = types.Int64PointerValue(r.ClientSecretRetentionPeriod)
-	if r.ClientSecretChangedTime != nil {
-		state.ClientSecretChangedTime = types.StringValue(r.ClientSecretChangedTime.Format(time.RFC3339Nano))
-	} else {
-		state.ClientSecretChangedTime = types.StringNull()
-	}
+	state.ClientSecretChangedTime = types.StringValue(r.GetClientSecretChangedTime().Format(time.RFC3339Nano))
 	state.TokenIntrospectionSigningAlgorithm = types.StringPointerValue(r.TokenIntrospectionSigningAlgorithm)
 	state.TokenIntrospectionEncryptionAlgorithm = types.StringPointerValue(r.TokenIntrospectionEncryptionAlgorithm)
 	state.TokenIntrospectionContentEncryptionAlgorithm = types.StringPointerValue(r.TokenIntrospectionContentEncryptionAlgorithm)

--- a/internal/resource/config/oauth/client/oauth_client_data_source.go
+++ b/internal/resource/config/oauth/client/oauth_client_data_source.go
@@ -617,7 +617,11 @@ func readOauthClientResponseDataSource(ctx context.Context, r *client.Client, st
 	for _, secondarySecretFromClient := range secondarySecretsFromClient {
 		secondarySecretAttrVal := map[string]attr.Value{}
 		secondarySecretAttrVal["encrypted_secret"] = types.StringPointerValue(secondarySecretFromClient.EncryptedSecret)
-		secondarySecretAttrVal["expiry_time"] = types.StringValue(secondarySecretFromClient.ExpiryTime.Format(time.RFC3339Nano))
+		if secondarySecretFromClient.ExpiryTime != nil {
+			secondarySecretAttrVal["expiry_time"] = types.StringValue(secondarySecretFromClient.ExpiryTime.Format(time.RFC3339Nano))
+		} else {
+			secondarySecretAttrVal["expiry_time"] = types.StringNull()
+		}
 		secondarySecretsAttrValObj, respDiags := types.ObjectValue(secondarySecretsDataSourceAttrType, secondarySecretAttrVal)
 		diags.Append(respDiags...)
 		secondarySecretsListSlice = append(secondarySecretsListSlice, secondarySecretsAttrValObj)

--- a/internal/resource/config/serversettings/systemkeys/server_settings_system_keys_data_source.go
+++ b/internal/resource/config/serversettings/systemkeys/server_settings_system_keys_data_source.go
@@ -125,24 +125,42 @@ func (r *serverSettingsSystemKeysDataSource) Configure(_ context.Context, req da
 func readServerSettingsSystemKeysDataSourceResponse(ctx context.Context, r *client.SystemKeys, state *serverSettingsSystemKeysModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	currentAttrs := r.GetCurrent()
+	var currentCreationDate types.String
+	if currentAttrs.CreationDate != nil {
+		currentCreationDate = types.StringValue(currentAttrs.CreationDate.Format(time.RFC3339Nano))
+	} else {
+		currentCreationDate = types.StringNull()
+	}
 	currentAttrVals := map[string]attr.Value{
-		"creation_date":      types.StringValue(currentAttrs.GetCreationDate().Format(time.RFC3339Nano)),
+		"creation_date":      currentCreationDate,
 		"encrypted_key_data": types.StringValue(currentAttrs.GetEncryptedKeyData()),
 	}
 	currentAttrsObjVal, respDiags := types.ObjectValue(systemKeyDataSourceAttrTypes, currentAttrVals)
 	diags = append(diags, respDiags...)
 
 	previousAttrs := r.GetPrevious()
+	var previousCreationDate types.String
+	if previousAttrs.CreationDate != nil {
+		previousCreationDate = types.StringValue(previousAttrs.CreationDate.Format(time.RFC3339Nano))
+	} else {
+		previousCreationDate = types.StringNull()
+	}
 	previousAttrVals := map[string]attr.Value{
-		"creation_date":      types.StringValue(previousAttrs.GetCreationDate().Format(time.RFC3339Nano)),
+		"creation_date":      previousCreationDate,
 		"encrypted_key_data": types.StringValue(previousAttrs.GetEncryptedKeyData()),
 	}
 	previousAttrsObjVal, respDiags := types.ObjectValue(systemKeyDataSourceAttrTypes, previousAttrVals)
 	diags = append(diags, respDiags...)
 
 	pendingAttrs := r.GetPending()
+	var pendingCreationDate types.String
+	if previousAttrs.CreationDate != nil {
+		pendingCreationDate = types.StringValue(pendingAttrs.CreationDate.Format(time.RFC3339Nano))
+	} else {
+		pendingCreationDate = types.StringNull()
+	}
 	pendingAttrVals := map[string]attr.Value{
-		"creation_date":      types.StringValue(pendingAttrs.GetCreationDate().Format(time.RFC3339Nano)),
+		"creation_date":      pendingCreationDate,
 		"encrypted_key_data": types.StringValue(pendingAttrs.GetEncryptedKeyData()),
 	}
 	pendingAttrsObjVal, respDiags := types.ObjectValue(systemKeyDataSourceAttrTypes, pendingAttrVals)

--- a/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
+++ b/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
@@ -223,7 +223,11 @@ func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) rea
 	// crypto_provider
 	state.CryptoProvider = types.StringPointerValue(response.CertView.CryptoProvider)
 	// expires
-	state.Expires = types.StringValue(response.CertView.Expires.Format(time.RFC3339))
+	if response.CertView.Expires != nil {
+		state.Expires = types.StringValue(response.CertView.Expires.Format(time.RFC3339))
+	} else {
+		state.Expires = types.StringNull()
+	}
 	// certificate_id
 	state.CertificateId = types.StringPointerValue(response.CertView.Id)
 	// on imports, read in the file_data value from the response
@@ -254,7 +258,11 @@ func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) rea
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.CertView.SubjectDN)
 	// valid_from
-	state.ValidFrom = types.StringValue(response.CertView.ValidFrom.Format(time.RFC3339))
+	if response.CertView.ValidFrom != nil {
+		state.ValidFrom = types.StringValue(response.CertView.ValidFrom.Format(time.RFC3339))
+	} else {
+		state.ValidFrom = types.StringNull()
+	}
 	// version
 	state.Version = types.Int64PointerValue(response.CertView.Version)
 	return respDiags


### PR DESCRIPTION
Fixes potential panics when formatting timestamp attributes