### PR TITLE
Disable 11.3 tests due to removed images

### DIFF
--- a/.github/workflows/scheduled-acctests.yaml
+++ b/.github/workflows/scheduled-acctests.yaml
@@ -18,8 +18,8 @@ jobs:
         # Cover oldest and newest patch release of the major-minor releases we support
         pingfederate:
           - "12.0.6"
-          - "12.1.4"
-          - "12.2.0"
+          - "12.1.8"
+          - "12.2.3"
       max-parallel: 1
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
No 11.3 latest images are available on docker hub anymore