### PR TITLE
Change ordered list attributes to unordered sets where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.2 (Unreleased)
+### Bug fixes
+* Updated many attributes that were implemented as ordered lists to instead be implemented as unordered sets, to better reflect the behavior of the PingFederate API. ([#544]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/544)))
+
 # v1.6.1 (Unreleased)
 ### Bug fixes
 * Fixed an inconsistent result error that would occur when configuring OAuth Clients with no `persistent_grant_expiration_time` supplied in the `pingfederate_oauth_client` resource for PF version `11.3`. ([#531]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/531)))

--- a/docs/data-sources/authentication_policies_fragment.md
+++ b/docs/data-sources/authentication_policies_fragment.md
@@ -195,7 +195,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -649,7 +649,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -938,7 +938,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1205,7 +1205,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1519,7 +1519,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1973,7 +1973,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2262,7 +2262,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2529,7 +2529,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2843,7 +2843,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -3297,7 +3297,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -3586,7 +3586,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -3853,7 +3853,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -4167,7 +4167,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -4621,7 +4621,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -4910,7 +4910,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -5177,7 +5177,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -5491,7 +5491,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -5945,7 +5945,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -6234,7 +6234,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -6501,7 +6501,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -6815,7 +6815,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -7269,7 +7269,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -7558,7 +7558,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -7825,7 +7825,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -8139,7 +8139,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -8593,7 +8593,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -8882,7 +8882,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -9149,7 +9149,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -9463,7 +9463,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -9917,7 +9917,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -10206,7 +10206,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -10473,7 +10473,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -10787,7 +10787,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -11241,7 +11241,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -11530,7 +11530,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -11797,7 +11797,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -12111,7 +12111,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -12565,7 +12565,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -12854,7 +12854,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -13121,7 +13121,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -13431,7 +13431,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--children--action--apc_mapping_policy_action--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -13885,7 +13885,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--children--action--fragment_policy_action--fragment_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -14174,7 +14174,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--outbound_attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -14441,7 +14441,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--root_node--children--children--children--children--children--children--children--children--children--children--action--local_identity_mapping_policy_action--inbound_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/data-sources/authentication_policy_contract.md
+++ b/docs/data-sources/authentication_policy_contract.md
@@ -27,7 +27,7 @@ data "pingfederate_authentication_policy_contract" "authenticationPolicyContract
 
 ### Read-Only
 
-- `core_attributes` (Attributes List) A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate. (see [below for nested schema](#nestedatt--core_attributes))
+- `core_attributes` (Attributes Set) A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate. (see [below for nested schema](#nestedatt--core_attributes))
 - `extended_attributes` (Attributes Set) A list of additional attributes as needed. (see [below for nested schema](#nestedatt--extended_attributes))
 - `id` (String) ID of this resource.
 - `name` (String) The Authentication Policy contract name. Name is unique.

--- a/docs/data-sources/cluster_status.md
+++ b/docs/data-sources/cluster_status.md
@@ -26,7 +26,7 @@ data "pingfederate_cluster_status" "clusterStatus" {
 - `last_config_update_time` (String) Time when the configuration of this node was last updated.
 - `last_replication_time` (String) Time when configuration changes were last replicated.
 - `mixed_mode` (Boolean) Indicates whether there is more than one version of PingFederate in the cluster.
-- `nodes` (Attributes List) List of nodes in the cluster. (see [below for nested schema](#nestedatt--nodes))
+- `nodes` (Attributes Set) List of nodes in the cluster. (see [below for nested schema](#nestedatt--nodes))
 - `replication_required` (Boolean) Indicates whether a replication is required to propagate config updates.
 
 <a id="nestedatt--nodes"></a>

--- a/docs/data-sources/data_store.md
+++ b/docs/data-sources/data_store.md
@@ -50,7 +50,7 @@ Read-Only:
 
 Read-Only:
 
-- `fields` (Attributes List) List of configuration fields. (see [below for nested schema](#nestedatt--custom_data_store--configuration--fields))
+- `fields` (Attributes Set) List of configuration fields. (see [below for nested schema](#nestedatt--custom_data_store--configuration--fields))
 - `tables` (Attributes List) List of configuration tables. (see [below for nested schema](#nestedatt--custom_data_store--configuration--tables))
 
 <a id="nestedatt--custom_data_store--configuration--fields"></a>
@@ -77,7 +77,7 @@ Read-Only:
 Read-Only:
 
 - `default_row` (Boolean) Whether this row is the default.
-- `fields` (Attributes List) The configuration fields in the row. (see [below for nested schema](#nestedatt--custom_data_store--configuration--tables--rows--fields))
+- `fields` (Attributes Set) The configuration fields in the row. (see [below for nested schema](#nestedatt--custom_data_store--configuration--tables--rows--fields))
 
 <a id="nestedatt--custom_data_store--configuration--tables--rows--fields"></a>
 ### Nested Schema for `custom_data_store.configuration.tables.rows.fields`

--- a/docs/data-sources/idp_adapter.md
+++ b/docs/data-sources/idp_adapter.md
@@ -157,7 +157,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.
@@ -294,7 +294,7 @@ Read-Only:
 
 Read-Only:
 
-- `fields` (Attributes List) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
+- `fields` (Attributes Set) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
 - `tables` (Attributes List) List of configuration tables. (see [below for nested schema](#nestedatt--configuration--tables))
 
 <a id="nestedatt--configuration--fields"></a>
@@ -321,7 +321,7 @@ Read-Only:
 Read-Only:
 
 - `default_row` (Boolean) Whether this row is the default.
-- `fields` (Attributes List) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
+- `fields` (Attributes Set) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
 
 <a id="nestedatt--configuration--tables--rows--fields"></a>
 ### Nested Schema for `configuration.tables.rows.fields`

--- a/docs/data-sources/idp_sp_connection.md
+++ b/docs/data-sources/idp_sp_connection.md
@@ -161,7 +161,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_query--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_query--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.
@@ -1010,7 +1010,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--adapter_override_settings--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--adapter_override_settings--attribute_mapping--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.
@@ -1240,7 +1240,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.
@@ -1529,7 +1529,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--authentication_policy_contract_assertion_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--sp_browser_sso--authentication_policy_contract_assertion_mappings--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.
@@ -1876,7 +1876,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--ws_trust--token_processor_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--ws_trust--token_processor_mappings--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.

--- a/docs/data-sources/license.md
+++ b/docs/data-sources/license.md
@@ -25,10 +25,10 @@ data "pingfederate_license" "myLicense" {
 - `bridge_mode` (Boolean) Indicates whether this license is a bridge license or not.
 - `enforcement_type` (String) The enforcement type is a 3-bit binary value, expressed as a decimal digit. The bits from left to right are: 1: Shutdown on expire. 2: Notify on expire. 4: Enforce minor version. if all three enforcements are active, the enforcement type will be 7 (1 + 2 + 4); if only the first two are active, you have an enforcement type of 3 (1 + 2).
 - `expiration_date` (String) The expiration date value from the license file (if applicable).
-- `features` (Attributes List) Other licence features, if applicable. (see [below for nested schema](#nestedatt--features))
+- `features` (Attributes Set) Other licence features, if applicable. (see [below for nested schema](#nestedatt--features))
 - `grace_period` (Number) Number of days provided as grace period, past the expiration date (if applicable).
 - `issue_date` (String) The issue date value from the license file.
-- `license_groups` (Attributes List) License connection groups, if applicable. (see [below for nested schema](#nestedatt--license_groups))
+- `license_groups` (Attributes Set) License connection groups, if applicable. (see [below for nested schema](#nestedatt--license_groups))
 - `max_connections` (Number) Maximum number of connections that can be created under this license (if applicable).
 - `name` (String) Name of the person the license was issued to.
 - `node_limit` (Number) Maximum number of clustered nodes allowed under this license (if applicable).

--- a/docs/data-sources/oauth_access_token_manager.md
+++ b/docs/data-sources/oauth_access_token_manager.md
@@ -43,7 +43,7 @@ data "pingfederate_oauth_access_token_manager" "myOauthAccessTokenManager" {
 
 Read-Only:
 
-- `allowed_clients` (Attributes List) If 'restrictClients' is true, this field defines the list of OAuth clients that are allowed to access the token manager. (see [below for nested schema](#nestedatt--access_control_settings--allowed_clients))
+- `allowed_clients` (Attributes Set) If 'restrictClients' is true, this field defines the list of OAuth clients that are allowed to access the token manager. (see [below for nested schema](#nestedatt--access_control_settings--allowed_clients))
 - `restrict_clients` (Boolean) Determines whether access to this token manager is restricted to specific OAuth clients. If false, the 'allowedClients' field is ignored. The default value is false.
 
 <a id="nestedatt--access_control_settings--allowed_clients"></a>
@@ -60,9 +60,9 @@ Read-Only:
 
 Read-Only:
 
-- `core_attributes` (Attributes List) A list of core token attributes that are associated with the access token management plugin type. This field is read-only and is ignored on POST/PUT. (see [below for nested schema](#nestedatt--attribute_contract--core_attributes))
+- `core_attributes` (Attributes Set) A list of core token attributes that are associated with the access token management plugin type. This field is read-only and is ignored on POST/PUT. (see [below for nested schema](#nestedatt--attribute_contract--core_attributes))
 - `default_subject_attribute` (String) Default subject attribute to use for audit logging when validating the access token. Blank value means to use USER_KEY attribute value after grant lookup.
-- `extended_attributes` (Attributes List) A list of additional token attributes that are associated with this access token management plugin instance. (see [below for nested schema](#nestedatt--attribute_contract--extended_attributes))
+- `extended_attributes` (Attributes Set) A list of additional token attributes that are associated with this access token management plugin instance. (see [below for nested schema](#nestedatt--attribute_contract--extended_attributes))
 
 <a id="nestedatt--attribute_contract--core_attributes"></a>
 ### Nested Schema for `attribute_contract.core_attributes`
@@ -88,7 +88,7 @@ Read-Only:
 
 Read-Only:
 
-- `fields` (Attributes List) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
+- `fields` (Attributes Set) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
 - `tables` (Attributes List) List of configuration tables. (see [below for nested schema](#nestedatt--configuration--tables))
 
 <a id="nestedatt--configuration--fields"></a>
@@ -115,7 +115,7 @@ Read-Only:
 Read-Only:
 
 - `default_row` (Boolean) Whether this row is the default.
-- `fields` (Attributes List) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
+- `fields` (Attributes Set) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
 
 <a id="nestedatt--configuration--tables--rows--fields"></a>
 ### Nested Schema for `configuration.tables.rows.fields`

--- a/docs/data-sources/oauth_token_exchange_token_generator_mapping.md
+++ b/docs/data-sources/oauth_token_exchange_token_generator_mapping.md
@@ -116,7 +116,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.

--- a/docs/data-sources/openid_connect_policy.md
+++ b/docs/data-sources/openid_connect_policy.md
@@ -179,7 +179,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.

--- a/docs/data-sources/password_credential_validator.md
+++ b/docs/data-sources/password_credential_validator.md
@@ -64,7 +64,7 @@ Read-Only:
 
 Read-Only:
 
-- `fields` (Attributes List) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
+- `fields` (Attributes Set) List of configuration fields. (see [below for nested schema](#nestedatt--configuration--fields))
 - `tables` (Attributes List) List of configuration tables. (see [below for nested schema](#nestedatt--configuration--tables))
 
 <a id="nestedatt--configuration--fields"></a>
@@ -91,7 +91,7 @@ Read-Only:
 Read-Only:
 
 - `default_row` (Boolean) Whether this row is the default.
-- `fields` (Attributes List) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
+- `fields` (Attributes Set) The configuration fields in the row. (see [below for nested schema](#nestedatt--configuration--tables--rows--fields))
 
 <a id="nestedatt--configuration--tables--rows--fields"></a>
 ### Nested Schema for `configuration.tables.rows.fields`

--- a/docs/data-sources/redirect_validation.md
+++ b/docs/data-sources/redirect_validation.md
@@ -34,8 +34,8 @@ Read-Only:
 - `enable_target_resource_validation_for_idp_discovery` (Boolean) Enable target resource validation for IdP discovery.
 - `enable_target_resource_validation_for_slo` (Boolean) Enable target resource validation for SLO.
 - `enable_target_resource_validation_for_sso` (Boolean) Enable target resource validation for SSO.
-- `uri_allow_list` (Attributes List) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
-- `white_list` (Attributes List) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
+- `uri_allow_list` (Attributes Set) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
+- `white_list` (Attributes Set) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
 
 <a id="nestedatt--redirect_validation_local_settings--uri_allow_list"></a>
 ### Nested Schema for `redirect_validation_local_settings.uri_allow_list`

--- a/docs/data-sources/sp_authentication_policy_contract_mapping.md
+++ b/docs/data-sources/sp_authentication_policy_contract_mapping.md
@@ -117,7 +117,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.

--- a/docs/data-sources/token_processor_to_token_generator_mapping.md
+++ b/docs/data-sources/token_processor_to_token_generator_mapping.md
@@ -117,7 +117,7 @@ Read-Only:
 Read-Only:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `data_store_ref` (Attributes) Reference to the associated data store. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--data_store_ref))
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `filter` (String) The JDBC WHERE clause used to query your data store to locate a user record.

--- a/docs/resources/authentication_policy_contract.md
+++ b/docs/resources/authentication_policy_contract.md
@@ -36,7 +36,7 @@ resource "pingfederate_authentication_policy_contract" "example" {
 
 ### Read-Only
 
-- `core_attributes` (Attributes List) A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate. (see [below for nested schema](#nestedatt--core_attributes))
+- `core_attributes` (Attributes Set) A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate. (see [below for nested schema](#nestedatt--core_attributes))
 - `id` (String) The ID of this resource.
 
 <a id="nestedatt--extended_attributes"></a>

--- a/docs/resources/certificates_group.md
+++ b/docs/resources/certificates_group.md
@@ -43,7 +43,7 @@ resource "pingfederate_certificates_group" "certGroup" {
 - `sha256_fingerprint` (String) SHA-256 fingerprint in Hex encoding.
 - `signature_algorithm` (String) The signature algorithm.
 - `status` (String) Status of the item.
-- `subject_alternative_names` (List of String) The subject alternative names (SAN).
+- `subject_alternative_names` (Set of String) The subject alternative names (SAN).
 - `subject_dn` (String) The subject's distinguished name.
 - `valid_from` (String) The start date from which the item is valid, in ISO 8601 format (UTC).
 - `version` (Number) The X.509 version to which the item conforms.

--- a/docs/resources/idp_adapter.md
+++ b/docs/resources/idp_adapter.md
@@ -413,7 +413,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/idp_sp_connection.md
+++ b/docs/resources/idp_sp_connection.md
@@ -510,7 +510,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_query--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1540,7 +1540,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--adapter_override_settings--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1786,7 +1786,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--adapter_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2157,7 +2157,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--sp_browser_sso--authentication_policy_contract_assertion_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2539,7 +2539,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--ws_trust--token_processor_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/idp_to_sp_adapter_mapping.md
+++ b/docs/resources/idp_to_sp_adapter_mapping.md
@@ -233,7 +233,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/license.md
+++ b/docs/resources/license.md
@@ -30,10 +30,10 @@ resource "pingfederate_license" "license" {
 - `bridge_mode` (Boolean) Indicates whether this license is a bridge license or not.
 - `enforcement_type` (String) The enforcement type is a 3-bit binary value, expressed as a decimal digit. The bits from left to right are: 1: Shutdown on expire. 2: Notify on expire. 4: Enforce minor version. if all three enforcements are active, the enforcement type will be 7 (1 + 2 + 4); if only the first two are active, you have an enforcement type of 3 (1 + 2).
 - `expiration_date` (String) The expiration date value from the license file (if applicable).
-- `features` (Attributes List) Other licence features, if applicable. (see [below for nested schema](#nestedatt--features))
+- `features` (Attributes Set) Other licence features, if applicable. (see [below for nested schema](#nestedatt--features))
 - `grace_period` (Number) Number of days provided as grace period, past the expiration date (if applicable).
 - `issue_date` (String) The issue date value from the license file.
-- `license_groups` (Attributes List) License connection groups, if applicable. (see [below for nested schema](#nestedatt--license_groups))
+- `license_groups` (Attributes Set) License connection groups, if applicable. (see [below for nested schema](#nestedatt--license_groups))
 - `max_connections` (Number) Maximum number of connections that can be created under this license (if applicable).
 - `name` (String) Name of the person the license was issued to.
 - `node_limit` (Number) Maximum number of clustered nodes allowed under this license (if applicable).

--- a/docs/resources/metadata_url.md
+++ b/docs/resources/metadata_url.md
@@ -75,7 +75,7 @@ Read-Only:
 - `sha256_fingerprint` (String) SHA-256 fingerprint in Hex encoding.
 - `signature_algorithm` (String) The signature algorithm.
 - `status` (String) Status of the item. Options are `VALID`, `EXPIRED`, `NOT_YET_VALID`, or `REVOKED`.
-- `subject_alternative_names` (List of String) The subject alternative names (SAN).
+- `subject_alternative_names` (Set of String) The subject alternative names (SAN).
 - `subject_dn` (String) The subject's distinguished name.
 - `valid_from` (String) The start date from which the item is valid, in ISO 8601 format (UTC).
 - `version` (Number) The X.509 version to which the item conforms.

--- a/docs/resources/oauth_access_token_manager.md
+++ b/docs/resources/oauth_access_token_manager.md
@@ -463,7 +463,7 @@ Required:
 
 Optional:
 
-- `allowed_clients` (Attributes List) If `restrict_clients` is `true`, this field defines the list of OAuth clients that are allowed to access the token manager. (see [below for nested schema](#nestedatt--access_control_settings--allowed_clients))
+- `allowed_clients` (Attributes Set) If `restrict_clients` is `true`, this field defines the list of OAuth clients that are allowed to access the token manager. (see [below for nested schema](#nestedatt--access_control_settings--allowed_clients))
 - `restrict_clients` (Boolean) Determines whether access to this token manager is restricted to specific OAuth clients. If `false`, the `allowed_clients` field is ignored. The default value is `false`.
 
 <a id="nestedatt--access_control_settings--allowed_clients"></a>

--- a/docs/resources/oauth_access_token_mapping.md
+++ b/docs/resources/oauth_access_token_mapping.md
@@ -277,7 +277,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/oauth_authentication_policy_contract_mapping.md
+++ b/docs/resources/oauth_authentication_policy_contract_mapping.md
@@ -194,7 +194,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/oauth_ciba_server_policy_request_policy.md
+++ b/docs/resources/oauth_ciba_server_policy_request_policy.md
@@ -199,7 +199,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--identity_hint_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -513,7 +513,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--identity_hint_contract_fulfillment--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/oauth_idp_adapter_mapping.md
+++ b/docs/resources/oauth_idp_adapter_mapping.md
@@ -345,7 +345,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/oauth_resource_owner_credentials_mapping.md
+++ b/docs/resources/oauth_resource_owner_credentials_mapping.md
@@ -191,7 +191,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/oauth_token_exchange_token_generator_mapping.md
+++ b/docs/resources/oauth_token_exchange_token_generator_mapping.md
@@ -281,7 +281,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/openid_connect_policy.md
+++ b/docs/resources/openid_connect_policy.md
@@ -357,7 +357,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/redirect_validation.md
+++ b/docs/resources/redirect_validation.md
@@ -74,8 +74,8 @@ Optional:
 - `enable_target_resource_validation_for_idp_discovery` (Boolean) Enable target resource validation for IdP discovery. Defaults to `false`.
 - `enable_target_resource_validation_for_slo` (Boolean) Enable target resource validation for SLO. Defaults to `false`.
 - `enable_target_resource_validation_for_sso` (Boolean) Enable target resource validation for SSO. Defaults to `false`.
-- `uri_allow_list` (Attributes List) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
-- `white_list` (Attributes List) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
+- `uri_allow_list` (Attributes Set) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
+- `white_list` (Attributes Set) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
 
 <a id="nestedatt--redirect_validation_local_settings--uri_allow_list"></a>
 ### Nested Schema for `redirect_validation_local_settings.uri_allow_list`

--- a/docs/resources/server_settings_ws_trust_sts_settings_issuer_certificate.md
+++ b/docs/resources/server_settings_ws_trust_sts_settings_issuer_certificate.md
@@ -43,7 +43,7 @@ resource "pingfederate_server_settings_ws_trust_sts_settings_issuer_certificate"
 - `sha256_fingerprint` (String) SHA-256 fingerprint in Hex encoding.
 - `signature_algorithm` (String) The signature algorithm.
 - `status` (String) Status of the item.
-- `subject_alternative_names` (List of String) The subject alternative names (SAN).
+- `subject_alternative_names` (Set of String) The subject alternative names (SAN).
 - `subject_dn` (String) The subject's distinguished name.
 - `valid_from` (String) The start date from which the item is valid, in ISO 8601 format (UTC).
 - `version` (Number) The X.509 version to which the item conforms.

--- a/docs/resources/sp_authentication_policy_contract_mapping.md
+++ b/docs/resources/sp_authentication_policy_contract_mapping.md
@@ -255,7 +255,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/sp_idp_connection.md
+++ b/docs/resources/sp_idp_connection.md
@@ -863,7 +863,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_browser_sso--adapter_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
 
@@ -1211,7 +1211,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_browser_sso--authentication_policy_contract_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -1772,7 +1772,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_browser_sso--sso_oauth_mapping--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2086,7 +2086,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--idp_oauth_grant_attribute_mapping--access_token_manager_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.
@@ -2853,7 +2853,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--ws_trust--token_generator_mappings--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/docs/resources/token_processor_to_token_generator_mapping.md
+++ b/docs/resources/token_processor_to_token_generator_mapping.md
@@ -269,7 +269,7 @@ Required:
 Optional:
 
 - `attribute_contract_fulfillment` (Attributes Map) Defines how an attribute in an attribute contract should be populated. (see [below for nested schema](#nestedatt--attribute_sources--jdbc_attribute_source--attribute_contract_fulfillment))
-- `column_names` (List of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
+- `column_names` (Set of String) A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.
 - `description` (String) The description of this attribute source. The description needs to be unique amongst the attribute sources for the mapping.<br>Note: Required for APC-to-SP Adapter Mappings
 - `id` (String) The ID that defines this attribute source. Only alphanumeric characters allowed. Note: Required for OpenID Connect policy attribute sources, OAuth IdP adapter mappings, OAuth access token mappings and APC-to-SP Adapter Mappings. IdP Connections will ignore this property since it only allows one attribute source to be defined per mapping. IdP-to-SP Adapter Mappings can contain multiple attribute sources.
 - `schema` (String) Lists the table structure that stores information within a database. Some databases, such as Oracle, require a schema for a JDBC query. Other databases, such as MySQL, do not require a schema.

--- a/internal/acctest/config/oauth/accesstokenmanager/json_web_oauth_access_token_manager_resource_gen_test.go
+++ b/internal/acctest/config/oauth/accesstokenmanager/json_web_oauth_access_token_manager_resource_gen_test.go
@@ -62,6 +62,11 @@ func TestAccOauthAccessTokenManager_MinimalMaximalJsonWeb(t *testing.T) {
 					"configuration.tables.0.rows.0.sensitive_fields",
 				},
 			},
+			{
+				// Back to complete model with fields reordered
+				Config: oauthAccessTokenManager_CompleteJsonWebHCLReordered(),
+				Check:  oauthAccessTokenManager_CheckComputedValuesCompleteJsonWeb(),
+			},
 		},
 	})
 }
@@ -356,6 +361,257 @@ resource "pingfederate_oauth_access_token_manager" "example" {
       },
       {
         name  = "Include Issued At Claim",
+        value = "false"
+      },
+	  %s
+    ]
+  }
+  name = "myATMUpdated"
+  plugin_descriptor_ref = {
+    id = "com.pingidentity.pf.access.token.management.plugins.JwtBearerAccessTokenManagementPlugin"
+  }
+  selection_settings = {
+    resource_uris = ["https://example.com"]
+  }
+  session_validation_settings = {
+    check_session_revocation_status = true
+    check_valid_authn_session       = true
+    include_session_id              = true
+    update_authn_session_activity   = true
+  }
+  %s
+}
+data "pingfederate_oauth_access_token_manager" "example" {
+  manager_id = pingfederate_oauth_access_token_manager.example.id
+}
+`, atmId, versionedFields, additionalVersionedHcl)
+}
+
+// Maximal HCL with all values set where possible, with collections reordered
+func oauthAccessTokenManager_CompleteJsonWebHCLReordered() string {
+	var versionedFields string
+	if acctest.VersionAtLeast(version.PingFederate1210) {
+		versionedFields += `
+  {
+	name  = "Publish Keys to the PingFederate JWKS Endpoint"
+	value = "false"
+  },
+`
+	}
+	additionalVersionedHcl := ""
+	if acctest.VersionAtLeast(version.PingFederate1220) {
+		additionalVersionedHcl += `
+token_endpoint_attribute_contract = {
+attributes = [
+  {
+	mapped_scopes = []
+	multi_valued  = true
+	name          = "another"
+  },
+  {
+	mapped_scopes = ["email"]
+	multi_valued  = false
+	name          = "normal"
+  },
+]
+}
+`
+	}
+
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_access_token_manager" "example" {
+  manager_id = "%s"
+  access_control_settings = {
+    allowed_clients  = []
+    restrict_clients = false
+  }
+  attribute_contract = {
+    default_subject_attribute = "contract1"
+    extended_attributes = [
+      {
+        name         = "contract1"
+        multi_valued = false
+      },
+      {
+        name         = "contract2"
+        multi_valued = true
+      },
+      {
+        name         = "contract"
+        multi_valued = false
+      },
+      {
+        name         = "contract3"
+        multi_valued = false
+      },
+      {
+        name         = "contract5"
+        multi_valued = false
+      },
+      {
+        name         = "contract4"
+        multi_valued = true
+      },
+    ]
+  }
+  configuration = {
+    tables = [
+      {
+        name = "Symmetric Keys"
+        rows = [
+          {
+            default_row = false
+            fields = [
+              {
+                name  = "Key ID"
+                value = "keyidentifier2"
+              },
+              {
+                name  = "Encoding"
+                value = "b64u"
+              }
+            ]
+            sensitive_fields = [
+              {
+                name  = "Key"
+                value = "e1oDxOiC3Jboz3um8hBVmW3JRZNo9z7C0DMm/oj2V1gclQRcgi2gKM2DBj9N05G4"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name = "Certificates"
+        rows = []
+      }
+    ]
+    fields = [
+      {
+        name  = "JWS Algorithm"
+        value = ""
+      },
+      {
+        name  = "Active Symmetric Key ID"
+        value = "keyidentifier2"
+      },
+      {
+        name  = "Active Signing Certificate Key ID"
+        value = ""
+      },
+      {
+        name  = "Token Lifetime"
+        value = "56"
+      },
+      {
+        name  = "Use Centralized Signing Key"
+        value = "false"
+      },
+      {
+        name  = "JWE Algorithm"
+        value = "dir"
+      },
+      {
+        name  = "JWE Content Encryption Algorithm"
+        value = "A192CBC-HS384"
+      },
+      {
+        name  = "Asymmetric Encryption JWKS URL"
+        value = ""
+      },
+      {
+        name  = "Enable Token Revocation"
+        value = "false"
+      },
+      {
+        name  = "Include Key ID Header Parameter"
+        value = "true"
+      },
+      {
+        name  = "Default JWKS URL Cache Duration"
+        value = "720"
+      },
+      {
+        name  = "Include JWE Key ID Header Parameter"
+        value = "true"
+      },
+      {
+        name  = "Active Symmetric Encryption Key ID"
+        value = "keyidentifier2"
+      },
+      {
+        name  = "Asymmetric Encryption Key"
+        value = ""
+      },
+      {
+        name  = "Client ID Claim Name"
+        value = "client_id"
+      },
+      {
+        name  = "Scope Claim Name"
+        value = "scope"
+      },
+      {
+        name  = "Space Delimit Scope Values"
+        value = "true"
+      },
+      {
+        name  = "Authorization Details Claim Name"
+        value = "authorization_details"
+      },
+      {
+        name  = "Issuer Claim Value"
+        value = ""
+      },
+      {
+        name  = "Audience Claim Value"
+        value = ""
+      },
+      {
+        name  = "JWT ID Claim Length"
+        value = "22"
+      },
+      {
+        name  = "Access Grant GUID Claim Name"
+        value = ""
+      },
+      {
+        name  = "JWKS Endpoint Path"
+        value = ""
+      },
+      {
+        name  = "JWKS Endpoint Cache Duration"
+        value = "720"
+      },
+      {
+        name  = "Expand Scope Groups"
+        value = "false"
+      },
+      {
+        name  = "Type Header Value"
+        value = ""
+      },
+      {
+        name  = "Publish Thumbprint X.509 URL"
+        value = "false"
+      },
+      {
+        name  = "Publish Key ID X.509 URL"
+        value = "false"
+      },
+      {
+        name  = "Include JWE X.509 Thumbprint Header Parameter",
+        value = "false"
+      },
+      {
+        name  = "Not Before Claim Offset"
+        value = ""
+      },
+      {
+        name  = "Include Issued At Claim",
+        value = "false"
+      },
+      {
+        name  = "Include X.509 Thumbprint Header Parameter",
         value = "false"
       },
 	  %s

--- a/internal/acctest/config/sp/targeturlmappings/sp_target_url_mappings_resource_gen_test.go
+++ b/internal/acctest/config/sp/targeturlmappings/sp_target_url_mappings_resource_gen_test.go
@@ -67,13 +67,6 @@ resource "pingfederate_sp_target_url_mappings" "example" {
       }
       type = "SP_ADAPTER"
       url  = "*"
-    },
-    {
-      ref = {
-        id = "spadapter"
-      }
-      type = "SP_ADAPTER"
-      url  = "example.com"
     }
   ]
 }

--- a/internal/acctest/config/sp/targeturlmappings/sp_target_url_mappings_resource_gen_test.go
+++ b/internal/acctest/config/sp/targeturlmappings/sp_target_url_mappings_resource_gen_test.go
@@ -67,6 +67,13 @@ resource "pingfederate_sp_target_url_mappings" "example" {
       }
       type = "SP_ADAPTER"
       url  = "*"
+    },
+    {
+      ref = {
+        id = "spadapter"
+      }
+      type = "SP_ADAPTER"
+      url  = "example.com"
     }
   ]
 }

--- a/internal/datasource/common/attributesources/attribute_sources_schema.go
+++ b/internal/datasource/common/attributesources/attribute_sources_schema.go
@@ -82,7 +82,7 @@ func JdbcAttributeSourceDataSourceSchemaAttributes() map[string]schema.Attribute
 		Optional:    false,
 		Computed:    true,
 	}
-	jdbcAttributeSourceDataSourceSchema["column_names"] = schema.ListAttribute{
+	jdbcAttributeSourceDataSourceSchema["column_names"] = schema.SetAttribute{
 		ElementType: types.StringType,
 		Optional:    false,
 		Computed:    true,

--- a/internal/datasource/common/pluginconfiguration/plugin_configuration_common.go
+++ b/internal/datasource/common/pluginconfiguration/plugin_configuration_common.go
@@ -15,7 +15,7 @@ var (
 	}
 
 	rowAttrTypes = map[string]attr.Type{
-		"fields":      types.ListType{ElemType: types.ObjectType{AttrTypes: fieldAttrTypes}},
+		"fields":      types.SetType{ElemType: types.ObjectType{AttrTypes: fieldAttrTypes}},
 		"default_row": types.BoolType,
 	}
 
@@ -25,7 +25,7 @@ var (
 	}
 
 	configurationAttrTypes = map[string]attr.Type{
-		"fields": types.ListType{ElemType: types.ObjectType{AttrTypes: fieldAttrTypes}},
+		"fields": types.SetType{ElemType: types.ObjectType{AttrTypes: fieldAttrTypes}},
 		"tables": types.ListType{ElemType: types.ObjectType{AttrTypes: tableAttrTypes}},
 	}
 )

--- a/internal/datasource/common/pluginconfiguration/plugin_configuration_schema.go
+++ b/internal/datasource/common/pluginconfiguration/plugin_configuration_schema.go
@@ -5,12 +5,12 @@ package pluginconfiguration
 import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ToDataSourceSchema() schema.SingleNestedAttribute {
-	fieldsListDefault, _ := types.ListValue(types.ObjectType{AttrTypes: fieldAttrTypes}, []attr.Value{})
+	fieldsSetDefault, _ := types.SetValue(types.ObjectType{AttrTypes: fieldAttrTypes}, []attr.Value{})
 	return schema.SingleNestedAttribute{
 		Description: "Plugin instance configuration.",
 		Required:    false,
@@ -37,7 +37,7 @@ func ToDataSourceSchema() schema.SingleNestedAttribute {
 							Computed:    true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
-									"fields": schema.ListNestedAttribute{
+									"fields": schema.SetNestedAttribute{
 										Description: "The configuration fields in the row.",
 										Required:    false,
 										Optional:    false,
@@ -77,12 +77,12 @@ func ToDataSourceSchema() schema.SingleNestedAttribute {
 					},
 				},
 			},
-			"fields": schema.ListNestedAttribute{
+			"fields": schema.SetNestedAttribute{
 				Description: "List of configuration fields.",
 				Required:    false,
 				Optional:    false,
 				Computed:    true,
-				Default:     listdefault.StaticValue(fieldsListDefault),
+				Default:     setdefault.StaticValue(fieldsSetDefault),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{

--- a/internal/datasource/common/pluginconfiguration/plugin_configuration_state.go
+++ b/internal/datasource/common/pluginconfiguration/plugin_configuration_state.go
@@ -14,7 +14,7 @@ import (
 
 func ToDataSourceState(con context.Context, configuration *client.PluginConfiguration) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	fieldsAttrValue, respDiags := types.ListValueFrom(con, types.ObjectType{AttrTypes: fieldAttrTypes}, configuration.Fields)
+	fieldsAttrValue, respDiags := types.SetValueFrom(con, types.ObjectType{AttrTypes: fieldAttrTypes}, configuration.Fields)
 	diags.Append(respDiags...)
 	tablesAttrValue, respDiags := types.ListValueFrom(con, types.ObjectType{AttrTypes: tableAttrTypes}, configuration.Tables)
 	diags.Append(respDiags...)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -151,7 +151,7 @@ type pingfederateProviderModel struct {
 	AccessToken                     types.String `tfsdk:"access_token"`
 	ClientId                        types.String `tfsdk:"client_id"`
 	ClientSecret                    types.String `tfsdk:"client_secret"`
-	Scopes                          types.List   `tfsdk:"scopes"`
+	Scopes                          types.Set    `tfsdk:"scopes"`
 	TokenUrl                        types.String `tfsdk:"token_url"`
 	InsecureTrustAllTls             types.Bool   `tfsdk:"insecure_trust_all_tls"`
 	CACertificatePEMFiles           types.Set    `tfsdk:"ca_certificate_pem_files"`
@@ -227,17 +227,17 @@ func (p *pingfederateProvider) Schema(_ context.Context, _ provider.SchemaReques
 				Description: "Set to true to trust any certificate when connecting to the PingFederate server. This is insecure and should not be enabled outside of testing. Default value can be set with the `PINGFEDERATE_PROVIDER_INSECURE_TRUST_ALL_TLS` environment variable.",
 				Optional:    true,
 			},
-			"scopes": schema.ListAttribute{
+			"scopes": schema.SetAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "OAuth scopes for access token. Default value can be set with the `PINGFEDERATE_PROVIDER_OAUTH_SCOPES` environment variable.",
 				Optional:            true,
-				Validators: []validator.List{
-					listvalidator.ConflictsWith(path.MatchRoot("access_token")),
-					listvalidator.ConflictsWith(path.MatchRoot("username")),
-					listvalidator.ConflictsWith(path.MatchRoot("password")),
-					listvalidator.AlsoRequires(path.MatchRoot("client_id")),
-					listvalidator.AlsoRequires(path.MatchRoot("client_secret")),
-					listvalidator.AlsoRequires(path.MatchRoot("token_url")),
+				Validators: []validator.Set{
+					setvalidator.ConflictsWith(path.MatchRoot("access_token")),
+					setvalidator.ConflictsWith(path.MatchRoot("username")),
+					setvalidator.ConflictsWith(path.MatchRoot("password")),
+					setvalidator.AlsoRequires(path.MatchRoot("client_id")),
+					setvalidator.AlsoRequires(path.MatchRoot("client_secret")),
+					setvalidator.AlsoRequires(path.MatchRoot("token_url")),
 				},
 			},
 			"token_url": schema.StringAttribute{

--- a/internal/resource/common/attributesources/attribute_sources_client_struct.go
+++ b/internal/resource/common/attributesources/attribute_sources_client_struct.go
@@ -72,7 +72,7 @@ func ClientStruct(attributeSourcesAttr basetypes.SetValue) []client.AttributeSou
 			}
 			if !jdbcAttributeSourceAttrs["column_names"].IsNull() && !jdbcAttributeSourceAttrs["column_names"].IsUnknown() {
 				attributeSourceInner.JdbcAttributeSource.ColumnNames = []string{}
-				for _, columnNamesElement := range jdbcAttributeSourceAttrs["column_names"].(types.List).Elements() {
+				for _, columnNamesElement := range jdbcAttributeSourceAttrs["column_names"].(types.Set).Elements() {
 					attributeSourceInner.JdbcAttributeSource.ColumnNames = append(attributeSourceInner.JdbcAttributeSource.ColumnNames, columnNamesElement.(types.String).ValueString())
 				}
 			}

--- a/internal/resource/common/attributesources/attribute_sources_schema.go
+++ b/internal/resource/common/attributesources/attribute_sources_schema.go
@@ -99,7 +99,7 @@ func jdbcAttributeSourceSchemaAttributes(optionalAndComputedNestedAttributeContr
 		Description: "The name of the database table. The name is used to construct the SQL query to retrieve data from the data store.",
 		Required:    true,
 	}
-	jdbcAttributeSourceSchema["column_names"] = schema.ListAttribute{
+	jdbcAttributeSourceSchema["column_names"] = schema.SetAttribute{
 		ElementType: types.StringType,
 		Optional:    true,
 		Description: "A list of column names used to construct the SQL query to retrieve data from the specified table in the datastore.",

--- a/internal/resource/common/attributesources/attribute_sources_state.go
+++ b/internal/resource/common/attributesources/attribute_sources_state.go
@@ -41,7 +41,7 @@ func jdbcAttributeSourceAttrType(includeIdAttr bool) map[string]attr.Type {
 	jdbcAttributeSourceAttrType := commonAttributeSourceAttrType(includeIdAttr)
 	jdbcAttributeSourceAttrType["schema"] = types.StringType
 	jdbcAttributeSourceAttrType["table"] = types.StringType
-	jdbcAttributeSourceAttrType["column_names"] = types.ListType{ElemType: types.StringType}
+	jdbcAttributeSourceAttrType["column_names"] = types.SetType{ElemType: types.StringType}
 	jdbcAttributeSourceAttrType["filter"] = types.StringType
 	return jdbcAttributeSourceAttrType
 }
@@ -128,7 +128,7 @@ func toStateInternal(con context.Context, attributeSourcesFromClient []client.At
 			jdbcAttrSourceValues := map[string]attr.Value{}
 			jdbcAttrSourceValues["schema"] = types.StringPointerValue(attrSource.JdbcAttributeSource.Schema)
 			jdbcAttrSourceValues["table"] = types.StringValue(attrSource.JdbcAttributeSource.Table)
-			jdbcAttrSourceValues["column_names"], valueFromDiags = types.ListValueFrom(con, types.StringType, attrSource.JdbcAttributeSource.ColumnNames)
+			jdbcAttrSourceValues["column_names"], valueFromDiags = types.SetValueFrom(con, types.StringType, attrSource.JdbcAttributeSource.ColumnNames)
 			diags.Append(valueFromDiags...)
 			jdbcAttrSourceValues["filter"] = types.StringValue(attrSource.JdbcAttributeSource.Filter)
 			jdbcAttrSourceValues["type"] = types.StringValue("JDBC")

--- a/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_data_source.go
+++ b/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_data_source.go
@@ -35,7 +35,7 @@ func (r *authenticationPolicyContractDataSource) Schema(ctx context.Context, req
 	schema := schema.Schema{
 		Description: "Describes an authentication policy contract.",
 		Attributes: map[string]schema.Attribute{
-			"core_attributes": schema.ListNestedAttribute{
+			"core_attributes": schema.SetNestedAttribute{
 				Description: "A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate.",
 				Computed:    true,
 				Optional:    false,

--- a/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_resource.go
+++ b/internal/resource/config/authenticationpolicycontract/authentication_policy_contract_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -38,8 +37,8 @@ var (
 	}
 
 	coreAttributesDefaultObjValue, _ = types.ObjectValue(coreAttributesDefaultObjAttrType, coreAttributesDefaultObjAttrValue)
-	coreAttributesDefaultListAttrVal = []attr.Value{coreAttributesDefaultObjValue}
-	coreAttributesDefaultListVal, _  = types.ListValue(attributeElemAttrType, coreAttributesDefaultListAttrVal)
+	coreAttributesDefaultSetAttrVal  = []attr.Value{coreAttributesDefaultObjValue}
+	coreAttributesDefaultSetVal, _   = types.SetValue(attributeElemAttrType, coreAttributesDefaultSetAttrVal)
 
 	customId = "contract_id"
 )
@@ -74,11 +73,11 @@ func (r *authenticationPolicyContractResource) Schema(ctx context.Context, req r
 					configvalidators.PingFederateId(),
 				},
 			},
-			"core_attributes": schema.ListNestedAttribute{
+			"core_attributes": schema.SetNestedAttribute{
 				Description: "A list of read-only assertion attributes (for example, subject) that are automatically populated by PingFederate.",
 				Computed:    true,
 				Optional:    false,
-				Default:     listdefault.StaticValue(coreAttributesDefaultListVal),
+				Default:     setdefault.StaticValue(coreAttributesDefaultSetVal),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{

--- a/internal/resource/config/authenticationpolicycontract/authentication_policy_contracts_common.go
+++ b/internal/resource/config/authenticationpolicycontract/authentication_policy_contracts_common.go
@@ -21,7 +21,7 @@ type authenticationPolicyContractModel struct {
 	Id                 types.String `tfsdk:"id"`
 	ContractId         types.String `tfsdk:"contract_id"`
 	Name               types.String `tfsdk:"name"`
-	CoreAttributes     types.List   `tfsdk:"core_attributes"`
+	CoreAttributes     types.Set    `tfsdk:"core_attributes"`
 	ExtendedAttributes types.Set    `tfsdk:"extended_attributes"`
 }
 
@@ -31,7 +31,7 @@ func readAuthenticationPolicyContractsResponse(ctx context.Context, r *client.Au
 	state.ContractId = types.StringPointerValue(r.Id)
 	state.Name = types.StringPointerValue(r.Name)
 
-	state.CoreAttributes, respDiags = types.ListValueFrom(ctx, attributeElemAttrType, r.GetCoreAttributes())
+	state.CoreAttributes, respDiags = types.SetValueFrom(ctx, attributeElemAttrType, r.GetCoreAttributes())
 	diags.Append(respDiags...)
 
 	state.ExtendedAttributes, respDiags = types.SetValueFrom(ctx, attributeElemAttrType, r.GetExtendedAttributes())

--- a/internal/resource/config/certificates/groups/certificates_group_resource_gen.go
+++ b/internal/resource/config/certificates/groups/certificates_group_resource_gen.go
@@ -72,7 +72,7 @@ type certificatesGroupResourceModel struct {
 	Sha256Fingerprint       types.String `tfsdk:"sha256_fingerprint"`
 	SignatureAlgorithm      types.String `tfsdk:"signature_algorithm"`
 	Status                  types.String `tfsdk:"status"`
-	SubjectAlternativeNames types.List   `tfsdk:"subject_alternative_names"`
+	SubjectAlternativeNames types.Set    `tfsdk:"subject_alternative_names"`
 	SubjectDn               types.String `tfsdk:"subject_dn"`
 	ValidFrom               types.String `tfsdk:"valid_from"`
 	Version                 types.Int64  `tfsdk:"version"`
@@ -164,7 +164,7 @@ func (r *certificatesGroupResource) Schema(ctx context.Context, req resource.Sch
 				Computed:    true,
 				Description: "Status of the item.",
 			},
-			"subject_alternative_names": schema.ListAttribute{
+			"subject_alternative_names": schema.SetAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
 				Description: "The subject alternative names (SAN).",
@@ -228,7 +228,7 @@ func (state *certificatesGroupResourceModel) readClientResponse(response *client
 	// status
 	state.Status = types.StringPointerValue(response.Status)
 	// subject_alternative_names
-	state.SubjectAlternativeNames, diags = types.ListValueFrom(context.Background(), types.StringType, response.SubjectAlternativeNames)
+	state.SubjectAlternativeNames, diags = types.SetValueFrom(context.Background(), types.StringType, response.SubjectAlternativeNames)
 	respDiags.Append(diags...)
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.SubjectDN)

--- a/internal/resource/config/cluster/status/cluster_status_data_source_gen.go
+++ b/internal/resource/config/cluster/status/cluster_status_data_source_gen.go
@@ -53,7 +53,7 @@ type clusterStatusDataSourceModel struct {
 	LastConfigUpdateTime types.String `tfsdk:"last_config_update_time"`
 	LastReplicationTime  types.String `tfsdk:"last_replication_time"`
 	MixedMode            types.Bool   `tfsdk:"mixed_mode"`
-	Nodes                types.List   `tfsdk:"nodes"`
+	Nodes                types.Set    `tfsdk:"nodes"`
 	ReplicationRequired  types.Bool   `tfsdk:"replication_required"`
 }
 
@@ -77,7 +77,7 @@ func (r *clusterStatusDataSource) Schema(ctx context.Context, req datasource.Sch
 				Computed:    true,
 				Description: "Indicates whether there is more than one version of PingFederate in the cluster.",
 			},
-			"nodes": schema.ListNestedAttribute{
+			"nodes": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"address": schema.StringAttribute{
@@ -231,7 +231,7 @@ func (state *clusterStatusDataSourceModel) readClientResponse(response *client.C
 		respDiags.Append(diags...)
 		nodesValues = append(nodesValues, nodesValue)
 	}
-	nodesValue, diags := types.ListValue(nodesElementType, nodesValues)
+	nodesValue, diags := types.SetValue(nodesElementType, nodesValues)
 	respDiags.Append(diags...)
 
 	state.Nodes = nodesValue
@@ -268,7 +268,7 @@ func (state *clusterStatusDataSourceModel) emptyModel() {
 		"version":                 types.StringType,
 	}
 	nodesElementType := types.ObjectType{AttrTypes: nodesAttrTypes}
-	state.Nodes = types.ListNull(nodesElementType)
+	state.Nodes = types.SetNull(nodesElementType)
 	// replication_required
 	state.ReplicationRequired = types.BoolNull()
 }

--- a/internal/resource/config/license/license_data_source.go
+++ b/internal/resource/config/license/license_data_source.go
@@ -45,12 +45,12 @@ type licenseDataSourceModel struct {
 	Organization        types.String `tfsdk:"organization"`
 	GracePeriod         types.Int64  `tfsdk:"grace_period"`
 	NodeLimit           types.Int64  `tfsdk:"node_limit"`
-	LicenseGroups       types.List   `tfsdk:"license_groups"`
+	LicenseGroups       types.Set    `tfsdk:"license_groups"`
 	OauthEnabled        types.Bool   `tfsdk:"oauth_enabled"`
 	WsTrustEnabled      types.Bool   `tfsdk:"ws_trust_enabled"`
 	ProvisioningEnabled types.Bool   `tfsdk:"provisioning_enabled"`
 	BridgeMode          types.Bool   `tfsdk:"bridge_mode"`
-	Features            types.List   `tfsdk:"features"`
+	Features            types.Set    `tfsdk:"features"`
 }
 
 // GetSchema defines the schema for the datasource.
@@ -130,7 +130,7 @@ func (r *licenseDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				Optional:    false,
 				Computed:    true,
 			},
-			"license_groups": schema.ListNestedAttribute{
+			"license_groups": schema.SetNestedAttribute{
 				Description: "License connection groups, if applicable.",
 				Required:    false,
 				Optional:    false,
@@ -188,7 +188,7 @@ func (r *licenseDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				Optional:    false,
 				Computed:    true,
 			},
-			"features": schema.ListNestedAttribute{
+			"features": schema.SetNestedAttribute{
 				Description: "Other licence features, if applicable.",
 				Required:    false,
 				Optional:    false,
@@ -259,10 +259,10 @@ func readLicenseResponseDataSource(ctx context.Context, r *client.LicenseView, s
 	state.ProvisioningEnabled = types.BoolValue(*r.ProvisioningEnabled)
 	state.BridgeMode = types.BoolValue(*r.BridgeMode)
 
-	state.LicenseGroups, respDiags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: licenseGroupsAttrTypes}, r.LicenseGroups)
+	state.LicenseGroups, respDiags = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: licenseGroupsAttrTypes}, r.LicenseGroups)
 	diags.Append(respDiags...)
 
-	state.Features, respDiags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: featuresAttrTypes}, r.Features)
+	state.Features, respDiags = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: featuresAttrTypes}, r.Features)
 	diags.Append(respDiags...)
 	return diags
 }

--- a/internal/resource/config/license/license_resource.go
+++ b/internal/resource/config/license/license_resource.go
@@ -65,12 +65,12 @@ type licenseResourceModel struct {
 	Organization        types.String `tfsdk:"organization"`
 	GracePeriod         types.Int64  `tfsdk:"grace_period"`
 	NodeLimit           types.Int64  `tfsdk:"node_limit"`
-	LicenseGroups       types.List   `tfsdk:"license_groups"`
+	LicenseGroups       types.Set    `tfsdk:"license_groups"`
 	OauthEnabled        types.Bool   `tfsdk:"oauth_enabled"`
 	WsTrustEnabled      types.Bool   `tfsdk:"ws_trust_enabled"`
 	ProvisioningEnabled types.Bool   `tfsdk:"provisioning_enabled"`
 	BridgeMode          types.Bool   `tfsdk:"bridge_mode"`
-	Features            types.List   `tfsdk:"features"`
+	Features            types.Set    `tfsdk:"features"`
 }
 
 // GetSchema defines the schema for the resource.
@@ -136,7 +136,7 @@ func (r *licenseResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Description: "Maximum number of clustered nodes allowed under this license (if applicable).",
 				Computed:    true,
 			},
-			"license_groups": schema.ListNestedAttribute{
+			"license_groups": schema.SetNestedAttribute{
 				Description: "License connection groups, if applicable.",
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
@@ -176,7 +176,7 @@ func (r *licenseResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Description: "Indicates whether this license is a bridge license or not.",
 				Computed:    true,
 			},
-			"features": schema.ListNestedAttribute{
+			"features": schema.SetNestedAttribute{
 				Description: "Other licence features, if applicable.",
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
@@ -242,10 +242,10 @@ func readLicenseResponse(ctx context.Context, r *client.LicenseView, state *lice
 	state.ProvisioningEnabled = types.BoolValue(*r.ProvisioningEnabled)
 	state.BridgeMode = types.BoolValue(*r.BridgeMode)
 
-	state.LicenseGroups, respDiags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: licenseGroupsAttrTypes}, r.LicenseGroups)
+	state.LicenseGroups, respDiags = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: licenseGroupsAttrTypes}, r.LicenseGroups)
 	diags.Append(respDiags...)
 
-	state.Features, respDiags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: featuresAttrTypes}, r.Features)
+	state.Features, respDiags = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: featuresAttrTypes}, r.Features)
 	diags.Append(respDiags...)
 	return diags
 }

--- a/internal/resource/config/metadataurls/metadata_url_resource_gen.go
+++ b/internal/resource/config/metadataurls/metadata_url_resource_gen.go
@@ -132,7 +132,7 @@ func (r *metadataUrlResource) Schema(ctx context.Context, req resource.SchemaReq
 							),
 						},
 					},
-					"subject_alternative_names": schema.ListAttribute{
+					"subject_alternative_names": schema.SetAttribute{
 						ElementType: types.StringType,
 						Computed:    true,
 						Description: "The subject alternative names (SAN).",
@@ -262,7 +262,7 @@ func (state *metadataUrlResourceModel) readClientResponse(response *client.Metad
 		"sha256_fingerprint":        types.StringType,
 		"signature_algorithm":       types.StringType,
 		"status":                    types.StringType,
-		"subject_alternative_names": types.ListType{ElemType: types.StringType},
+		"subject_alternative_names": types.SetType{ElemType: types.StringType},
 		"subject_dn":                types.StringType,
 		"valid_from":                types.StringType,
 		"version":                   types.Int64Type,
@@ -271,7 +271,7 @@ func (state *metadataUrlResourceModel) readClientResponse(response *client.Metad
 	if response.CertView == nil {
 		certViewValue = types.ObjectNull(certViewAttrTypes)
 	} else {
-		certViewSubjectAlternativeNamesValue, diags := types.ListValueFrom(context.Background(), types.StringType, response.CertView.SubjectAlternativeNames)
+		certViewSubjectAlternativeNamesValue, diags := types.SetValueFrom(context.Background(), types.StringType, response.CertView.SubjectAlternativeNames)
 		respDiags.Append(diags...)
 		var expires types.String
 		if response.CertView.Expires != nil {

--- a/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_data_source.go
+++ b/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_data_source.go
@@ -37,8 +37,8 @@ var (
 	}
 
 	attributeContractAttrTypes = map[string]attr.Type{
-		"core_attributes":           types.ListType{ElemType: types.ObjectType{AttrTypes: coreAttributeTypes}},
-		"extended_attributes":       types.ListType{ElemType: types.ObjectType{AttrTypes: extendedAttributeTypes}},
+		"core_attributes":           types.SetType{ElemType: types.ObjectType{AttrTypes: coreAttributeTypes}},
+		"extended_attributes":       types.SetType{ElemType: types.ObjectType{AttrTypes: extendedAttributeTypes}},
 		"default_subject_attribute": types.StringType,
 	}
 )
@@ -100,7 +100,7 @@ func (r *oauthAccessTokenManagerDataSource) Schema(ctx context.Context, req data
 				Optional:    false,
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"core_attributes": schema.ListNestedAttribute{
+					"core_attributes": schema.SetNestedAttribute{
 						Description: "A list of core token attributes that are associated with the access token management plugin type. This field is read-only and is ignored on POST/PUT.",
 						Required:    false,
 						Optional:    false,
@@ -122,7 +122,7 @@ func (r *oauthAccessTokenManagerDataSource) Schema(ctx context.Context, req data
 							},
 						},
 					},
-					"extended_attributes": schema.ListNestedAttribute{
+					"extended_attributes": schema.SetNestedAttribute{
 						Description: "A list of additional token attributes that are associated with this access token management plugin instance.",
 						Required:    false,
 						Optional:    false,
@@ -179,7 +179,7 @@ func (r *oauthAccessTokenManagerDataSource) Schema(ctx context.Context, req data
 						Optional:    false,
 						Computed:    true,
 					},
-					"allowed_clients": schema.ListNestedAttribute{
+					"allowed_clients": schema.SetNestedAttribute{
 						Description: "If 'restrictClients' is true, this field defines the list of OAuth clients that are allowed to access the token manager.",
 						Required:    false,
 						Optional:    false,

--- a/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource.go
+++ b/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource.go
@@ -15,7 +15,7 @@ var (
 
 	accessControlSettingsAttrType = map[string]attr.Type{
 		"restrict_clients": types.BoolType,
-		"allowed_clients":  types.ListType{ElemType: types.ObjectType{AttrTypes: resourcelink.AttrType()}},
+		"allowed_clients":  types.SetType{ElemType: types.ObjectType{AttrTypes: resourcelink.AttrType()}},
 	}
 
 	sessionValidationSettingsAttrType = map[string]attr.Type{
@@ -30,7 +30,7 @@ var (
 		"resource_uris": resourceUrisDefault,
 	})
 
-	allowedClientsDefault, _        = types.ListValue(types.ObjectType{AttrTypes: resourcelink.AttrType()}, nil)
+	allowedClientsDefault, _        = types.SetValue(types.ObjectType{AttrTypes: resourcelink.AttrType()}, nil)
 	accessControlSettingsDefault, _ = types.ObjectValue(accessControlSettingsAttrType, map[string]attr.Value{
 		"restrict_clients": types.BoolValue(false),
 		"allowed_clients":  allowedClientsDefault,

--- a/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource_gen.go
+++ b/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource_gen.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
@@ -85,7 +84,7 @@ func (r *oauthAccessTokenManagerResource) Schema(ctx context.Context, req resour
 		"id": types.StringType,
 	}
 	accessControlSettingsAllowedClientsElementType := types.ObjectType{AttrTypes: accessControlSettingsAllowedClientsAttrTypes}
-	accessControlSettingsAllowedClientsDefault, diags := types.ListValue(accessControlSettingsAllowedClientsElementType, nil)
+	accessControlSettingsAllowedClientsDefault, diags := types.SetValue(accessControlSettingsAllowedClientsElementType, nil)
 	resp.Diagnostics.Append(diags...)
 	// selection_settings.resource_uris default
 	selectionSettingsResourceUrisDefault, diags := types.SetValue(types.StringType, nil)
@@ -108,7 +107,7 @@ func (r *oauthAccessTokenManagerResource) Schema(ctx context.Context, req resour
 		Attributes: map[string]schema.Attribute{
 			"access_control_settings": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"allowed_clients": schema.ListNestedAttribute{
+					"allowed_clients": schema.SetNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"id": schema.StringAttribute{
@@ -123,7 +122,7 @@ func (r *oauthAccessTokenManagerResource) Schema(ctx context.Context, req resour
 						Optional:    true,
 						Computed:    true,
 						Description: "If `restrict_clients` is `true`, this field defines the list of OAuth clients that are allowed to access the token manager.",
-						Default:     listdefault.StaticValue(accessControlSettingsAllowedClientsDefault),
+						Default:     setdefault.StaticValue(accessControlSettingsAllowedClientsDefault),
 					},
 					"restrict_clients": schema.BoolAttribute{
 						Computed:    true,
@@ -406,7 +405,7 @@ func (model *oauthAccessTokenManagerResourceModel) buildClientStruct() (*client.
 		accessControlSettingsValue := &client.AtmAccessControlSettings{}
 		accessControlSettingsAttrs := model.AccessControlSettings.Attributes()
 		accessControlSettingsValue.AllowedClients = []client.ResourceLink{}
-		for _, allowedClientsElement := range accessControlSettingsAttrs["allowed_clients"].(types.List).Elements() {
+		for _, allowedClientsElement := range accessControlSettingsAttrs["allowed_clients"].(types.Set).Elements() {
 			allowedClientsValue := client.ResourceLink{}
 			allowedClientsAttrs := allowedClientsElement.(types.Object).Attributes()
 			allowedClientsValue.Id = allowedClientsAttrs["id"].(types.String).ValueString()
@@ -522,7 +521,7 @@ func (state *oauthAccessTokenManagerResourceModel) readClientResponse(response *
 	}
 	accessControlSettingsAllowedClientsElementType := types.ObjectType{AttrTypes: accessControlSettingsAllowedClientsAttrTypes}
 	accessControlSettingsAttrTypes := map[string]attr.Type{
-		"allowed_clients":  types.ListType{ElemType: accessControlSettingsAllowedClientsElementType},
+		"allowed_clients":  types.SetType{ElemType: accessControlSettingsAllowedClientsElementType},
 		"restrict_clients": types.BoolType,
 	}
 	var accessControlSettingsValue types.Object
@@ -537,7 +536,7 @@ func (state *oauthAccessTokenManagerResourceModel) readClientResponse(response *
 			respDiags.Append(diags...)
 			accessControlSettingsAllowedClientsValues = append(accessControlSettingsAllowedClientsValues, accessControlSettingsAllowedClientsValue)
 		}
-		accessControlSettingsAllowedClientsValue, diags := types.ListValue(accessControlSettingsAllowedClientsElementType, accessControlSettingsAllowedClientsValues)
+		accessControlSettingsAllowedClientsValue, diags := types.SetValue(accessControlSettingsAllowedClientsElementType, accessControlSettingsAllowedClientsValues)
 		respDiags.Append(diags...)
 		accessControlSettingsValue, diags = types.ObjectValue(accessControlSettingsAttrTypes, map[string]attr.Value{
 			"allowed_clients":  accessControlSettingsAllowedClientsValue,

--- a/internal/resource/config/redirectvalidation/redirect_validation_data_source.go
+++ b/internal/resource/config/redirectvalidation/redirect_validation_data_source.go
@@ -59,7 +59,7 @@ func (r *redirectValidationDataSource) Schema(ctx context.Context, req datasourc
 						Computed:    true,
 						Optional:    false,
 					},
-					"white_list": schema.ListNestedAttribute{
+					"white_list": schema.SetNestedAttribute{
 						Description: "List of URLs that are designated as valid target resources.",
 						Computed:    true,
 						Optional:    false,
@@ -108,7 +108,7 @@ func (r *redirectValidationDataSource) Schema(ctx context.Context, req datasourc
 							},
 						},
 					},
-					"uri_allow_list": schema.ListNestedAttribute{
+					"uri_allow_list": schema.SetNestedAttribute{
 						Description: "List of URIs that are designated as valid target resources.",
 						Computed:    true,
 						Optional:    false,

--- a/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
+++ b/internal/resource/config/serversettings/wstruststssettings/issuercertificates/server_settings_ws_trust_sts_settings_issuer_certificate_resource.go
@@ -73,7 +73,7 @@ type serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel struct {
 	Sha256Fingerprint       types.String `tfsdk:"sha256_fingerprint"`
 	SignatureAlgorithm      types.String `tfsdk:"signature_algorithm"`
 	Status                  types.String `tfsdk:"status"`
-	SubjectAlternativeNames types.List   `tfsdk:"subject_alternative_names"`
+	SubjectAlternativeNames types.Set    `tfsdk:"subject_alternative_names"`
 	SubjectDn               types.String `tfsdk:"subject_dn"`
 	ValidFrom               types.String `tfsdk:"valid_from"`
 	Version                 types.Int64  `tfsdk:"version"`
@@ -159,7 +159,7 @@ func (r *serverSettingsWsTrustStsSettingsIssuerCertificateResource) Schema(ctx c
 				Computed:    true,
 				Description: "Status of the item.",
 			},
-			"subject_alternative_names": schema.ListAttribute{
+			"subject_alternative_names": schema.SetAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
 				Description: "The subject alternative names (SAN).",
@@ -253,7 +253,7 @@ func (state *serverSettingsWsTrustStsSettingsIssuerCertificateResourceModel) rea
 	// status
 	state.Status = types.StringPointerValue(response.CertView.Status)
 	// subject_alternative_names
-	state.SubjectAlternativeNames, diags = types.ListValueFrom(context.Background(), types.StringType, response.CertView.SubjectAlternativeNames)
+	state.SubjectAlternativeNames, diags = types.SetValueFrom(context.Background(), types.StringType, response.CertView.SubjectAlternativeNames)
 	respDiags.Append(diags...)
 	// subject_dn
 	state.SubjectDn = types.StringPointerValue(response.CertView.SubjectDN)


### PR DESCRIPTION
The updated attributes will not have any functional changes, and will reflect the actual behavior of the PingFederate API.

- provider configuration: `scopes`
- various resources: `attribute_sources.*.jdbc_attribute_source.column_names`
- various data sources: `configuration.fields`
- `authentication_policy_contract`: `core_attributes`
- `certificates_group`: `subject_alternative_names`
- `metadata_url`: `subject_alternative_names`
- `server_settings_ws_trust_sts_settings_issuer_certificate`: `subject_alternative_names`
- `cluster_status`: `nodes`
- `license`: `features` and `license_groups`
- `oauth_access_token_manager`: `core_attributes`, `extended_attributes`, `allowed_clients`
- `redirect_validation`: `white_list` and `uri_allow_list`