### PR TITLE
Disable 12.0 tests

### DIFF
--- a/.github/workflows/scheduled-acctests.yaml
+++ b/.github/workflows/scheduled-acctests.yaml
@@ -17,7 +17,6 @@ jobs:
           - "1.11.*"
         # Cover newest patch release of the major-minor releases we support
         pingfederate:
-          - "12.0.6"
           - "12.1.8"
           - "12.2.4"
           - "12.3.0"


### PR DESCRIPTION
- Disable PF 12.0 tests as the version is no longer available on DockerHub, and is EOL.