### PR TITLE
Require specific gosec version

### DIFF
--- a/.github/workflows/gosec-scan.yml
+++ b/.github/workflows/gosec-scan.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v6
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.23.0
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif ./...'


### PR DESCRIPTION
- Update the security scan action job to use `securego/gosec@v2.23.0` (the latest) instead of relying on their `master`.
- Security scans had been failing for a couple weeks