### PR TITLE
Coalescing nil to empty string for attribute sources values

### DIFF
--- a/.changelog/pr-600.txt
+++ b/.changelog/pr-600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed potential inconsistent result errors which could be caused when setting `custom_attribute_source.filter_fields[i].value` to an empty string
+```

--- a/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
+++ b/internal/acctest/config/authenticationpolicies/fragments/authentication_policies_fragment_test.go
@@ -169,7 +169,8 @@ resource "pingfederate_authentication_policies_fragment" "%[1]s" {
                     description = "APIStubs"
                     filter_fields = [
                       {
-                        name = "Authorization Header"
+                        name  = "Authorization Header"
+                        value = ""
                       },
                       {
                         name = "Body"

--- a/internal/acctest/config/idptospadaptermapping/idp_to_sp_adapter_mapping_resource_gen_test.go
+++ b/internal/acctest/config/idptospadaptermapping/idp_to_sp_adapter_mapping_resource_gen_test.go
@@ -6,6 +6,7 @@ package idptospadaptermapping_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -93,6 +94,34 @@ func TestAccIdpToSpAdapterMapping_MinimalMaximal(t *testing.T) {
 	})
 }
 
+func TestAccIdpToSpAdapterMapping_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: idpToSpAdapterMapping_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: idpToSpAdapterMapping_CustomAttributeSourceHCL("/users/external"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_idp_to_sp_adapter_mapping.custom_source", "attribute_sources.#", "1"),
+					idpToSpAdapterMapping_CheckCustomFilterFieldValue("pingfederate_idp_to_sp_adapter_mapping.custom_source", "Authorization Header", ""),
+					idpToSpAdapterMapping_CheckCustomFilterFieldValue("pingfederate_idp_to_sp_adapter_mapping.custom_source", "Resource Path", "/users/external"),
+				),
+			},
+			{
+				Config: idpToSpAdapterMapping_CustomAttributeSourceHCL("/users/internal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_idp_to_sp_adapter_mapping.custom_source", "attribute_sources.#", "1"),
+					idpToSpAdapterMapping_CheckCustomFilterFieldValue("pingfederate_idp_to_sp_adapter_mapping.custom_source", "Authorization Header", ""),
+					idpToSpAdapterMapping_CheckCustomFilterFieldValue("pingfederate_idp_to_sp_adapter_mapping.custom_source", "Resource Path", "/users/internal"),
+				),
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func idpToSpAdapterMapping_MinimalHCL() string {
 	return fmt.Sprintf(`
@@ -136,6 +165,83 @@ resource "pingfederate_idp_to_sp_adapter_mapping" "example" {
 `, attributesources.Hcl(nil, attributesources.LdapClientStruct("(cn=Example)", "SUBTREE", *client.NewResourceLink("pingdirectory"))),
 		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()),
 		idpAdapterId, spAdapterId)
+}
+
+func idpToSpAdapterMapping_CustomAttributeSourceHCL(resourcePath string) string {
+	return fmt.Sprintf(`
+resource "pingfederate_idp_to_sp_adapter_mapping" "custom_source" {
+  application_icon_url = "https://example.com/icon.png"
+  application_name     = "My Application"
+  attribute_contract_fulfillment = {
+    "subject" = {
+      source = {
+        type = "ADAPTER"
+      }
+      value = "subject"
+    }
+  }
+  attribute_sources = [
+    {
+      custom_attribute_source = {
+        data_store_ref = {
+          id = "customDataStore"
+        }
+        description = "APIStubs"
+        filter_fields = [
+          {
+            name = "Authorization Header"
+          },
+          {
+            name = "Body"
+          },
+          {
+            name  = "Resource Path"
+            value = "%s"
+          },
+        ]
+        id = "APIStubs"
+      }
+    }
+  ]
+  default_target_resource = "https://example.com"
+  %s
+  source_id = "%s"
+  target_id = "%s"
+}
+`, resourcePath,
+		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()),
+		idpAdapterId, spAdapterId)
+}
+
+func idpToSpAdapterMapping_CheckCustomFilterFieldValue(resourceName, filterName, expectedValue string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		stateResource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		for key, value := range stateResource.Primary.Attributes {
+			if !strings.Contains(key, ".custom_attribute_source.filter_fields.") || !strings.HasSuffix(key, ".name") {
+				continue
+			}
+			if value != filterName {
+				continue
+			}
+
+			valueKey := strings.TrimSuffix(key, ".name") + ".value"
+			actualValue, exists := stateResource.Primary.Attributes[valueKey]
+			if !exists {
+				return fmt.Errorf("expected %q filter field to have value key %q", filterName, valueKey)
+			}
+			if actualValue != expectedValue {
+				return fmt.Errorf("unexpected value for %q filter field: got %q, want %q", filterName, actualValue, expectedValue)
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("did not find filter field %q in resource state", filterName)
+	}
 }
 
 // Validate any computed values when applying minimal HCL

--- a/internal/acctest/config/idptospadaptermapping/idp_to_sp_adapter_mapping_resource_gen_test.go
+++ b/internal/acctest/config/idptospadaptermapping/idp_to_sp_adapter_mapping_resource_gen_test.go
@@ -189,7 +189,8 @@ resource "pingfederate_idp_to_sp_adapter_mapping" "custom_source" {
         description = "APIStubs"
         filter_fields = [
           {
-            name = "Authorization Header"
+            name  = "Authorization Header"
+            value = ""
           },
           {
             name = "Body"

--- a/internal/acctest/config/oauth/authenticationpolicycontractmappings/oauth_authentication_policy_contract_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/authenticationpolicycontractmappings/oauth_authentication_policy_contract_mapping_resource_gen_test.go
@@ -236,7 +236,8 @@ resource "pingfederate_oauth_authentication_policy_contract_mapping" "custom_sou
         description = "APIStubs"
         filter_fields = [
           {
-            name = "Authorization Header"
+            name  = "Authorization Header"
+            value = ""
           },
           {
             name = "Body"

--- a/internal/acctest/config/oauth/authenticationpolicycontractmappings/oauth_authentication_policy_contract_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/authenticationpolicycontractmappings/oauth_authentication_policy_contract_mapping_resource_gen_test.go
@@ -91,6 +91,54 @@ func TestAccOauthAuthenticationPolicyContractMapping_MinimalMaximal(t *testing.T
 	})
 }
 
+func TestAccOauthAuthenticationPolicyContractMapping_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthAuthenticationPolicyContractMapping_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oauthAuthenticationPolicyContractMapping_CustomAttributeSourceHCL("/users/external"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config: oauthAuthenticationPolicyContractMapping_CustomAttributeSourceHCL("/users/internal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_authentication_policy_contract_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/internal",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
 func oauthAuthenticationPolicyContractMapping_DependencyHCL() string {
 	return fmt.Sprintf(`
 resource "pingfederate_authentication_policy_contract" "oauth_auth_policy_mapping_contract" {
@@ -158,6 +206,57 @@ resource "pingfederate_oauth_authentication_policy_contract_mapping" "example" {
 }
 %s
 `, attributesources.Hcl(nil, attributesources.LdapClientStruct("(cn=Example)", "SUBTREE", *client.NewResourceLink("pingdirectory"))),
+		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()),
+		oauthAuthenticationPolicyContractMapping_DependencyHCL())
+}
+
+func oauthAuthenticationPolicyContractMapping_CustomAttributeSourceHCL(resourcePath string) string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_authentication_policy_contract_mapping" "custom_source" {
+  attribute_contract_fulfillment = {
+    "USER_NAME" = {
+      source = {
+        type = "AUTHENTICATION_POLICY_CONTRACT"
+      }
+      value = "subject"
+    }
+    "USER_KEY" = {
+      source = {
+        type = "AUTHENTICATION_POLICY_CONTRACT"
+      }
+      value = "ImmutableID"
+    }
+  }
+  attribute_sources = [
+    {
+      custom_attribute_source = {
+        data_store_ref = {
+          id = "customDataStore"
+        }
+        description = "APIStubs"
+        filter_fields = [
+          {
+            name = "Authorization Header"
+          },
+          {
+            name = "Body"
+          },
+          {
+            name  = "Resource Path"
+            value = "%s"
+          },
+        ]
+        id = "APIStubs"
+      }
+    }
+  ]
+  authentication_policy_contract_ref = {
+    id = pingfederate_authentication_policy_contract.oauth_auth_policy_mapping_contract.contract_id
+  }
+  %s
+}
+%s
+`, resourcePath,
 		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()),
 		oauthAuthenticationPolicyContractMapping_DependencyHCL())
 }

--- a/internal/acctest/config/oauth/cibaserverpolicy/requestpolicies/oauth_ciba_server_policy_request_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/cibaserverpolicy/requestpolicies/oauth_ciba_server_policy_request_policy_resource_gen_test.go
@@ -306,7 +306,8 @@ resource "pingfederate_oauth_ciba_server_policy_request_policy" "custom_source" 
               name = "Authorization Header"
             },
             {
-              name = "Body"
+              name  = "Body"
+              value = ""
             },
             {
               name  = "Resource Path"

--- a/internal/acctest/config/oauth/cibaserverpolicy/requestpolicies/oauth_ciba_server_policy_request_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/cibaserverpolicy/requestpolicies/oauth_ciba_server_policy_request_policy_resource_gen_test.go
@@ -89,6 +89,55 @@ func TestAccOauthCibaServerPolicyRequestPolicy_MinimalMaximal(t *testing.T) {
 	})
 }
 
+func TestAccOauthCibaServerPolicyRequestPolicy_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthCibaServerPolicyRequestPolicy_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oauthCibaServerPolicyRequestPolicy_CustomAttributeSourceHCL("My Request Policy", 120),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "identity_hint_contract_fulfillment.attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "identity_hint_contract_fulfillment.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "identity_hint_contract_fulfillment.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config: oauthCibaServerPolicyRequestPolicy_CustomAttributeSourceHCL("My Request Policy Updated", 121),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "name", "My Request Policy Updated"),
+					resource.TestCheckResourceAttr("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "transaction_lifetime", "121"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "identity_hint_contract_fulfillment.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_ciba_server_policy_request_policy.custom_source", "identity_hint_contract_fulfillment.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func oauthCibaServerPolicyRequestPolicy_MinimalHCL() string {
 	return fmt.Sprintf(`
@@ -197,6 +246,81 @@ resource "pingfederate_oauth_ciba_server_policy_request_policy" "example" {
 `, oauthCibaServerPolicyRequestPolicyPolicyId,
 		attributesources.Hcl(nil, attributesources.LdapClientStruct("(cn=Example)", "SUBTREE", *client.NewResourceLink("pingdirectory"))),
 		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()))
+}
+
+func oauthCibaServerPolicyRequestPolicy_CustomAttributeSourceHCL(name string, transactionLifetime int) string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_ciba_server_policy_request_policy" "custom_source" {
+  policy_id = "%s"
+  authenticator_ref = {
+    id = "exampleCibaAuthenticator"
+  }
+  identity_hint_mapping = {
+    attribute_contract_fulfillment = {
+      "subject" = {
+        source = {
+          type = "REQUEST"
+        }
+        value = "IDENTITY_HINT_SUBJECT"
+      }
+      "USER_KEY" = {
+        source = {
+          type = "REQUEST"
+        }
+        value = "IDENTITY_HINT_SUBJECT"
+      }
+    }
+  }
+  identity_hint_contract = {
+    extended_attributes = [
+      {
+        name = "anotherone"
+      }
+    ]
+  }
+  identity_hint_contract_fulfillment = {
+    attribute_contract_fulfillment = {
+      "IDENTITY_HINT_SUBJECT" = {
+        source = {
+          type = "REQUEST"
+        }
+        value = "IDENTITY_HINT_SUBJECT"
+      }
+      "anotherone" = {
+        source = {
+          type = "REQUEST"
+        }
+        value = "anotherone"
+      }
+    }
+    attribute_sources = [
+      {
+        custom_attribute_source = {
+          data_store_ref = {
+            id = "customDataStore"
+          }
+          description = "APIStubs"
+          id          = "APIStubs"
+          filter_fields = [
+            {
+              name = "Authorization Header"
+            },
+            {
+              name = "Body"
+            },
+            {
+              name  = "Resource Path"
+              value = "/users/external"
+            },
+          ]
+        }
+      }
+    ]
+  }
+  transaction_lifetime = %d
+  name                 = "%s"
+}
+`, oauthCibaServerPolicyRequestPolicyPolicyId, transactionLifetime, name)
 }
 
 // Validate any computed values when applying minimal HCL

--- a/internal/acctest/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen_test.go
@@ -218,7 +218,8 @@ resource "pingfederate_oauth_idp_adapter_mapping" "custom_source" {
         description = "APIStubs"
         filter_fields = [
           {
-            name = "Authorization Header"
+            name  = "Authorization Header"
+            value = ""
           },
           {
             name = "Body"

--- a/internal/acctest/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/idpadaptermappings/oauth_idp_adapter_mapping_resource_gen_test.go
@@ -91,6 +91,54 @@ func TestAccOauthIdpAdapterMapping_MinimalMaximal(t *testing.T) {
 	})
 }
 
+func TestAccOauthIdpAdapterMapping_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthIdpAdapterMapping_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oauthIdpAdapterMapping_CustomAttributeSourceHCL("/users/external"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config: oauthIdpAdapterMapping_CustomAttributeSourceHCL("/users/internal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_idp_adapter_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/internal",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func oauthIdpAdapterMapping_MinimalHCL() string {
 	return fmt.Sprintf(`
@@ -140,6 +188,54 @@ resource "pingfederate_oauth_idp_adapter_mapping" "example" {
 }
 `, oauthIdpAdapterMappingMappingId,
 		attributesources.Hcl(nil, attributesources.LdapClientStruct("(cn=Example)", "SUBTREE", *client.NewResourceLink("pingdirectory"))),
+		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()))
+}
+
+func oauthIdpAdapterMapping_CustomAttributeSourceHCL(resourcePath string) string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_idp_adapter_mapping" "custom_source" {
+  mapping_id = "%s"
+  attribute_contract_fulfillment = {
+    "USER_NAME" = {
+      source = {
+        type = "ADAPTER"
+      }
+      value = "subject"
+    }
+    "USER_KEY" = {
+      source = {
+        type = "ADAPTER"
+      }
+      value = "uid"
+    }
+  }
+  attribute_sources = [
+    {
+      custom_attribute_source = {
+        data_store_ref = {
+          id = "customDataStore"
+        }
+        description = "APIStubs"
+        filter_fields = [
+          {
+            name = "Authorization Header"
+          },
+          {
+            name = "Body"
+          },
+          {
+            name  = "Resource Path"
+            value = "%s"
+          },
+        ]
+        id = "APIStubs"
+      }
+    }
+  ]
+  %s
+}
+`, oauthIdpAdapterMappingMappingId,
+		resourcePath,
 		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()))
 }
 

--- a/internal/acctest/config/oauth/openidconnect/policy/openid_connect_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/openidconnect/policy/openid_connect_policy_resource_gen_test.go
@@ -88,6 +88,38 @@ func TestAccOpenidConnectPolicy_MinimalMaximal(t *testing.T) {
 	})
 }
 
+func TestAccOpenidConnectPolicy_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: openidConnectPolicy_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: openidConnectPolicy_CustomAttributeSourceHCL(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_openid_connect_policy.custom_source", "attribute_mapping.attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_openid_connect_policy.custom_source", "attribute_mapping.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config:                               openidConnectPolicy_CustomAttributeSourceHCL(),
+				ResourceName:                         "pingfederate_openid_connect_policy.custom_source",
+				ImportStateId:                        openidConnectPolicyPolicyId,
+				ImportStateVerifyIdentifierAttribute: "policy_id",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func openidConnectPolicy_MinimalHCL() string {
 	return fmt.Sprintf(`
@@ -362,6 +394,113 @@ data "pingfederate_openid_connect_policy" "example" {
   policy_id = pingfederate_openid_connect_policy.example.policy_id
 }
 `, openidConnectPolicyPolicyId, versionedHcl)
+}
+
+func openidConnectPolicy_CustomAttributeSourceHCL() string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_access_token_manager" "custom_source" {
+  manager_id = "oidcJsonWebTokenCustomSrc"
+  name       = "oidcJsonWebTokenCustomSrc"
+  plugin_descriptor_ref = {
+    id = "com.pingidentity.pf.access.token.management.plugins.JwtBearerAccessTokenManagementPlugin"
+  }
+  configuration = {
+    tables = [
+      {
+        name = "Symmetric Keys"
+        rows = [
+          {
+            fields = [
+              {
+                name  = "Key ID"
+                value = "keyidentifier"
+              },
+              {
+                name  = "Encoding"
+                value = "b64u"
+              }
+            ]
+            sensitive_fields = [
+              {
+                name  = "Key"
+                value = "e1oDxOiC3Jboz3um8hBVmW3JRZNo9z7C0DMm/oj2V1gclQRcgi2gKM2DBj9N05G4"
+              },
+            ]
+          }
+        ]
+      },
+      {
+        name = "Certificates"
+        rows = []
+      }
+    ]
+    fields = [
+      {
+        name  = "JWE Algorithm"
+        value = "dir"
+      },
+      {
+        name  = "JWE Content Encryption Algorithm"
+        value = "A192CBC-HS384"
+      },
+      {
+        name  = "Active Symmetric Encryption Key ID"
+        value = "keyidentifier"
+      },
+    ]
+  }
+  attribute_contract = {
+    extended_attributes = [
+      {
+        name = "contract"
+      }
+    ]
+  }
+}
+
+resource "pingfederate_openid_connect_policy" "custom_source" {
+  policy_id = "%s"
+  access_token_manager_ref = {
+    id = pingfederate_oauth_access_token_manager.custom_source.id
+  }
+  attribute_contract = {
+  }
+  attribute_mapping = {
+    attribute_contract_fulfillment = {
+      "sub" = {
+        source = {
+          type = "TOKEN"
+        }
+        value = "contract"
+      }
+    }
+    attribute_sources = [
+      {
+        custom_attribute_source = {
+          data_store_ref = {
+            id = "customDataStore"
+          }
+          description = "APIStubs"
+          id          = "APIStubs"
+          filter_fields = [
+            {
+              name = "Authorization Header"
+            },
+            {
+              name = "Body"
+            },
+            {
+              name  = "Resource Path"
+              value = "/users/external"
+            },
+          ]
+        }
+      }
+    ]
+  }
+  name = "oidc-custom-source-policy"
+}
+`, openidConnectPolicyPolicyId)
 }
 
 // Validate any computed values when applying minimal HCL

--- a/internal/acctest/config/oauth/openidconnect/policy/openid_connect_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/openidconnect/policy/openid_connect_policy_resource_gen_test.go
@@ -487,7 +487,8 @@ resource "pingfederate_openid_connect_policy" "custom_source" {
               name = "Authorization Header"
             },
             {
-              name = "Body"
+              name  = "Body"
+              value = ""
             },
             {
               name  = "Resource Path"

--- a/internal/acctest/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen_test.go
@@ -285,7 +285,8 @@ resource "pingfederate_oauth_token_exchange_processor_policy" "custom_source" {
             description = "APIStubs"
             filter_fields = [
               {
-                name = "Authorization Header"
+                name  = "Authorization Header"
+                value = ""
               },
               {
                 name = "Body"

--- a/internal/acctest/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen_test.go
+++ b/internal/acctest/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen_test.go
@@ -89,6 +89,54 @@ func TestAccOauthTokenExchangeProcessorPolicy_MinimalMaximal(t *testing.T) {
 	})
 }
 
+func TestAccOauthTokenExchangeProcessorPolicy_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthTokenExchangeProcessorPolicy_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oauthTokenExchangeProcessorPolicy_CustomAttributeSourceHCL("/users/external"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config: oauthTokenExchangeProcessorPolicy_CustomAttributeSourceHCL("/users/internal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_processor_policy.custom_source", "processor_mappings.0.attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/internal",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
 func dependencyTokenProcessorHCL() string {
 	return `
 resource "pingfederate_idp_token_processor" "saml2" {
@@ -192,6 +240,74 @@ resource "pingfederate_oauth_token_exchange_processor_policy" "example" {
 `, dependencyTokenProcessorHCL(), oauthTokenExchangeProcessorPolicyPolicyId,
 		attributesources.Hcl(nil, attributesources.LdapClientStruct("(cn=Example)", "SUBTREE", *client.NewResourceLink("pingdirectory"))),
 		issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()))
+}
+
+func oauthTokenExchangeProcessorPolicy_CustomAttributeSourceHCL(resourcePath string) string {
+	return fmt.Sprintf(`
+%s
+resource "pingfederate_oauth_token_exchange_processor_policy" "custom_source" {
+  policy_id            = "%s"
+  actor_token_required = true
+  attribute_contract = {
+    extended_attributes = [
+      {
+        name = "extendedattr"
+      }
+    ]
+  }
+  name = "My updated processor policy"
+  processor_mappings = [
+    {
+      actor_token_processor = {
+        id = pingfederate_idp_token_processor.saml2.processor_id
+      }
+      actor_token_type = "urn:ietf:params:oauth:token-type:saml2"
+      attribute_contract_fulfillment = {
+        "subject" = {
+          source = {
+            type = "CONTEXT"
+          }
+          value = "ClientId"
+        },
+        "extendedattr" = {
+          source = {
+            type = "TEXT"
+          }
+          value = "value"
+        }
+      }
+      attribute_sources = [
+        {
+          custom_attribute_source = {
+            data_store_ref = {
+              id = "customDataStore"
+            }
+            description = "APIStubs"
+            filter_fields = [
+              {
+                name = "Authorization Header"
+              },
+              {
+                name = "Body"
+              },
+              {
+                name  = "Resource Path"
+                value = "%s"
+              },
+            ]
+            id = "APIStubs"
+          }
+        }
+      ]
+			%s
+      subject_token_processor = {
+        id = pingfederate_idp_token_processor.saml2.processor_id
+      }
+      subject_token_type = "urn:ietf:params:oauth:token-type:saml2"
+    }
+  ]
+}
+`, dependencyTokenProcessorHCL(), oauthTokenExchangeProcessorPolicyPolicyId, resourcePath, issuancecriteria.Hcl(issuancecriteria.ConditionalCriteria()))
 }
 
 // Validate any computed values when applying minimal HCL

--- a/internal/acctest/config/oauth/tokenexchange/tokengeneratormapping/oauth_token_exchange_token_generator_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/tokenexchange/tokengeneratormapping/oauth_token_exchange_token_generator_mapping_resource_gen_test.go
@@ -229,7 +229,8 @@ resource "pingfederate_oauth_token_exchange_token_generator_mapping" "custom_sou
           name = "Authorization Header"
         },
         {
-          name = "Body"
+          name  = "Body"
+          value = ""
         },
         {
           name  = "Resource Path"

--- a/internal/acctest/config/oauth/tokenexchange/tokengeneratormapping/oauth_token_exchange_token_generator_mapping_resource_gen_test.go
+++ b/internal/acctest/config/oauth/tokenexchange/tokengeneratormapping/oauth_token_exchange_token_generator_mapping_resource_gen_test.go
@@ -87,6 +87,54 @@ func TestAccOauthTokenExchangeTokenGeneratorMapping_MinimalMaximal(t *testing.T)
 	})
 }
 
+func TestAccOauthTokenExchangeTokenGeneratorMapping_CustomAttributeSourceRoundTrip(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthTokenExchangeTokenGeneratorMapping_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: oauthTokenExchangeTokenGeneratorMapping_CustomAttributeSourceHCL("/users/external"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/external",
+						},
+					),
+				),
+			},
+			{
+				Config: oauthTokenExchangeTokenGeneratorMapping_CustomAttributeSourceHCL("/users/internal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Authorization Header",
+							"value": "",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("pingfederate_oauth_token_exchange_token_generator_mapping.custom_source", "attribute_sources.*.custom_attribute_source.filter_fields.*",
+						map[string]string{
+							"name":  "Resource Path",
+							"value": "/users/internal",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func oauthTokenExchangeTokenGeneratorMapping_MinimalHCL() string {
 	return `
@@ -157,6 +205,57 @@ data "pingfederate_oauth_token_exchange_token_generator_mapping" "example" {
   mapping_id = pingfederate_oauth_token_exchange_token_generator_mapping.example.id
 }
 `
+}
+
+func oauthTokenExchangeTokenGeneratorMapping_CustomAttributeSourceHCL(resourcePath string) string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_token_exchange_token_generator_mapping" "custom_source" {
+  attribute_contract_fulfillment = {
+    "SAML_SUBJECT" = {
+      source = {
+        type = "CONTEXT"
+      }
+      value = "ClientIp"
+    }
+  }
+  attribute_sources = [{
+    custom_attribute_source = {
+      data_store_ref = {
+        id = "customDataStore"
+      }
+      description = "APIStubs"
+      filter_fields = [
+        {
+          name = "Authorization Header"
+        },
+        {
+          name = "Body"
+        },
+        {
+          name  = "Resource Path"
+          value = "%s"
+        },
+      ]
+      id = "APIStubs"
+    }
+  }]
+  issuance_criteria = {
+    conditional_criteria = [
+      {
+        attribute_name = "SAML_SUBJECT"
+        condition      = "MULTIVALUE_CONTAINS_DN"
+        source = {
+          type = "MAPPED_ATTRIBUTES"
+        }
+        value = "cn=Example,dc=example,dc=com"
+      },
+    ]
+    expression_criteria = null
+  }
+  source_id = "tokenexchangeprocessorpolicy"
+  target_id = "tokengenerator"
+}
+`, resourcePath)
 }
 
 // Validate any computed values when applying minimal HCL

--- a/internal/resource/common/attributemapping/attribute_mapping.go
+++ b/internal/resource/common/attributemapping/attribute_mapping.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/pingfederate-go-client/v1300/configurationapi"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/attributecontractfulfillment"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/attributesources"
@@ -61,6 +62,14 @@ func toSchemaInternal(required, includeValueDefault bool) schema.SingleNestedAtt
 }
 
 func ToState(con context.Context, attributeMappingFromClient *configurationapi.AttributeMapping) (types.Object, diag.Diagnostics) {
+	return toStateInternal(con, attributeMappingFromClient, true)
+}
+
+func ToStateNoValueDefault(con context.Context, attributeMappingFromClient *configurationapi.AttributeMapping) (types.Object, diag.Diagnostics) {
+	return toStateInternal(con, attributeMappingFromClient, false)
+}
+
+func toStateInternal(con context.Context, attributeMappingFromClient *configurationapi.AttributeMapping, includeValueDefault bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if attributeMappingFromClient == nil {
@@ -72,7 +81,12 @@ func ToState(con context.Context, attributeMappingFromClient *configurationapi.A
 	attributeContractFulfillment, objDiags := attributecontractfulfillment.ToState(con, &attributeMappingFromClient.AttributeContractFulfillment)
 	diags = append(diags, objDiags...)
 
-	attributeSources, objDiags := attributesources.ToState(con, attributeMappingFromClient.AttributeSources)
+	var attributeSources basetypes.SetValue
+	if includeValueDefault {
+		attributeSources, objDiags = attributesources.ToState(con, attributeMappingFromClient.AttributeSources)
+	} else {
+		attributeSources, objDiags = attributesources.ToStateNoValueDefault(con, attributeMappingFromClient.AttributeSources)
+	}
 	diags = append(diags, objDiags...)
 
 	issuanceCriteria, objDiags := issuancecriteria.ToState(con, attributeMappingFromClient.IssuanceCriteria)

--- a/internal/resource/common/attributesources/attribute_sources_state.go
+++ b/internal/resource/common/attributesources/attribute_sources_state.go
@@ -86,14 +86,33 @@ func attrTypesInternal(includeIdAttr bool) map[string]attr.Type {
 }
 
 func ToState(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation) (basetypes.SetValue, diag.Diagnostics) {
-	return toStateInternal(con, attributeSourcesFromClient, true)
+	return toStateInternal(con, attributeSourcesFromClient, true, true)
 }
 
 func ToStateNoId(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation) (basetypes.SetValue, diag.Diagnostics) {
-	return toStateInternal(con, attributeSourcesFromClient, false)
+	return toStateInternal(con, attributeSourcesFromClient, false, true)
 }
 
-func toStateInternal(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation, includeIdAttr bool) (basetypes.SetValue, diag.Diagnostics) {
+func ToStateNoValueDefault(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation) (basetypes.SetValue, diag.Diagnostics) {
+	return toStateInternal(con, attributeSourcesFromClient, true, false)
+}
+
+func normalizeFieldEntryNilValuesToEmpty(fields []client.FieldEntry) []client.FieldEntry {
+	if len(fields) == 0 {
+		return fields
+	}
+	normalized := make([]client.FieldEntry, len(fields))
+	for i := range fields {
+		normalized[i] = fields[i]
+		if normalized[i].Value == nil {
+			empty := ""
+			normalized[i].Value = &empty
+		}
+	}
+	return normalized
+}
+
+func toStateInternal(con context.Context, attributeSourcesFromClient []client.AttributeSourceAggregation, includeIdAttr, normalizeNullFilterFieldValueToEmpty bool) (basetypes.SetValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var customAttrSourceAttrTypes = customAttributeSourceAttrType(includeIdAttr)
 	var jdbcAttrSourceAttrTypes = jdbcAttributeSourceAttrType(includeIdAttr)
@@ -107,7 +126,11 @@ func toStateInternal(con context.Context, attributeSourcesFromClient []client.At
 		attrSourceValues := map[string]attr.Value{}
 		if attrSource.CustomAttributeSource != nil {
 			customAttrSourceValues := map[string]attr.Value{}
-			customAttrSourceValues["filter_fields"], valueFromDiags = types.SetValueFrom(con, customAttrSourceAttrTypes["filter_fields"].(types.SetType).ElemType, attrSource.CustomAttributeSource.FilterFields)
+			filterFields := attrSource.CustomAttributeSource.FilterFields
+			if normalizeNullFilterFieldValueToEmpty {
+				filterFields = normalizeFieldEntryNilValuesToEmpty(filterFields)
+			}
+			customAttrSourceValues["filter_fields"], valueFromDiags = types.SetValueFrom(con, customAttrSourceAttrTypes["filter_fields"].(types.SetType).ElemType, filterFields)
 			diags.Append(valueFromDiags...)
 
 			customAttrSourceValues["type"] = types.StringValue("CUSTOM")

--- a/internal/resource/common/authenticationpolicytreenode/authentication_policy_tree_node_state.go
+++ b/internal/resource/common/authenticationpolicytreenode/authentication_policy_tree_node_state.go
@@ -33,10 +33,14 @@ func childrenAttrTypes(depth int) types.ListType {
 }
 
 func ToState(ctx context.Context, node *client.AuthenticationPolicyTreeNode) (types.Object, diag.Diagnostics) {
-	return recursiveState(ctx, node, 1, GetRootNodeAttrTypes())
+	return recursiveState(ctx, node, 1, GetRootNodeAttrTypes(), true)
 }
 
-func recursiveState(ctx context.Context, node *client.AuthenticationPolicyTreeNode, depth int, attrTypes map[string]attr.Type) (types.Object, diag.Diagnostics) {
+func ToStateNoValueDefault(ctx context.Context, node *client.AuthenticationPolicyTreeNode) (types.Object, diag.Diagnostics) {
+	return recursiveState(ctx, node, 1, GetRootNodeAttrTypes(), false)
+}
+
+func recursiveState(ctx context.Context, node *client.AuthenticationPolicyTreeNode, depth int, attrTypes map[string]attr.Type, includeValueDefault bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if node == nil {
 		diags.AddError(providererror.InternalProviderError, "provided authentication policy tree node is nil")
@@ -44,7 +48,11 @@ func recursiveState(ctx context.Context, node *client.AuthenticationPolicyTreeNo
 	}
 	var attrValues = map[string]attr.Value{}
 
-	attrValues["action"], diags = policyaction.ToState(ctx, &node.Action)
+	if includeValueDefault {
+		attrValues["action"], diags = policyaction.ToState(ctx, &node.Action)
+	} else {
+		attrValues["action"], diags = policyaction.ToStateNoValueDefault(ctx, &node.Action)
+	}
 	if diags.HasError() {
 		return types.ObjectNull(attrTypes), diags
 	}
@@ -53,7 +61,7 @@ func recursiveState(ctx context.Context, node *client.AuthenticationPolicyTreeNo
 		childrenType := attrTypes["children"].(types.ListType).ElemType.(types.ObjectType)
 		children := []attr.Value{}
 		for i := range node.Children {
-			childObj, diags := recursiveState(ctx, &node.Children[i], depth+1, childrenType.AttrTypes)
+			childObj, diags := recursiveState(ctx, &node.Children[i], depth+1, childrenType.AttrTypes, includeValueDefault)
 			if diags.HasError() {
 				return types.ObjectNull(attrTypes), diags
 			}

--- a/internal/resource/common/policyaction/policy_action_state.go
+++ b/internal/resource/common/policyaction/policy_action_state.go
@@ -85,6 +85,14 @@ func AttrTypes() map[string]attr.Type {
 }
 
 func ToState(ctx context.Context, response *client.PolicyActionAggregation) (types.Object, diag.Diagnostics) {
+	return toStateInternal(ctx, response, true)
+}
+
+func ToStateNoValueDefault(ctx context.Context, response *client.PolicyActionAggregation) (types.Object, diag.Diagnostics) {
+	return toStateInternal(ctx, response, false)
+}
+
+func toStateInternal(ctx context.Context, response *client.PolicyActionAggregation, includeValueDefault bool) (types.Object, diag.Diagnostics) {
 	var diags, respDiags diag.Diagnostics
 	if response == nil {
 		diags.AddError(providererror.InternalProviderError, "provided client struct is nil")
@@ -109,7 +117,11 @@ func ToState(ctx context.Context, response *client.PolicyActionAggregation) (typ
 		}
 		actionAttrs["authentication_policy_contract_ref"], respDiags = resourcelink.ToState(ctx, &response.ApcMappingPolicyAction.AuthenticationPolicyContractRef)
 		diags.Append(respDiags...)
-		actionAttrs["attribute_mapping"], respDiags = attributemapping.ToState(ctx, &response.ApcMappingPolicyAction.AttributeMapping)
+		if includeValueDefault {
+			actionAttrs["attribute_mapping"], respDiags = attributemapping.ToState(ctx, &response.ApcMappingPolicyAction.AttributeMapping)
+		} else {
+			actionAttrs["attribute_mapping"], respDiags = attributemapping.ToStateNoValueDefault(ctx, &response.ApcMappingPolicyAction.AttributeMapping)
+		}
 		diags.Append(respDiags...)
 		attrs["apc_mapping_policy_action"], respDiags = types.ObjectValue(apcMappingPolicyActionAttrTypes, actionAttrs)
 		diags.Append(respDiags...)
@@ -159,7 +171,11 @@ func ToState(ctx context.Context, response *client.PolicyActionAggregation) (typ
 		diags.Append(respDiags...)
 		actionAttrs["fragment"], respDiags = resourcelink.ToState(ctx, &response.FragmentPolicyAction.Fragment)
 		diags.Append(respDiags...)
-		actionAttrs["fragment_mapping"], respDiags = attributemapping.ToState(ctx, response.FragmentPolicyAction.FragmentMapping)
+		if includeValueDefault {
+			actionAttrs["fragment_mapping"], respDiags = attributemapping.ToState(ctx, response.FragmentPolicyAction.FragmentMapping)
+		} else {
+			actionAttrs["fragment_mapping"], respDiags = attributemapping.ToStateNoValueDefault(ctx, response.FragmentPolicyAction.FragmentMapping)
+		}
 		diags.Append(respDiags...)
 		attrs["fragment_policy_action"], respDiags = types.ObjectValue(fragmentPolicyActionAttrTypes, actionAttrs)
 		diags.Append(respDiags...)
@@ -170,9 +186,15 @@ func ToState(ctx context.Context, response *client.PolicyActionAggregation) (typ
 		}
 		actionAttrs["local_identity_ref"], respDiags = resourcelink.ToState(ctx, &response.LocalIdentityMappingPolicyAction.LocalIdentityRef)
 		diags.Append(respDiags...)
-		actionAttrs["inbound_mapping"], respDiags = attributemapping.ToState(ctx, response.LocalIdentityMappingPolicyAction.InboundMapping)
-		diags.Append(respDiags...)
-		actionAttrs["outbound_attribute_mapping"], respDiags = attributemapping.ToState(ctx, &response.LocalIdentityMappingPolicyAction.OutboundAttributeMapping)
+		if includeValueDefault {
+			actionAttrs["inbound_mapping"], respDiags = attributemapping.ToState(ctx, response.LocalIdentityMappingPolicyAction.InboundMapping)
+			diags.Append(respDiags...)
+			actionAttrs["outbound_attribute_mapping"], respDiags = attributemapping.ToState(ctx, &response.LocalIdentityMappingPolicyAction.OutboundAttributeMapping)
+		} else {
+			actionAttrs["inbound_mapping"], respDiags = attributemapping.ToStateNoValueDefault(ctx, response.LocalIdentityMappingPolicyAction.InboundMapping)
+			diags.Append(respDiags...)
+			actionAttrs["outbound_attribute_mapping"], respDiags = attributemapping.ToStateNoValueDefault(ctx, &response.LocalIdentityMappingPolicyAction.OutboundAttributeMapping)
+		}
 		diags.Append(respDiags...)
 		attrs["local_identity_mapping_policy_action"], respDiags = types.ObjectValue(localIdentityMappingPolicyActionAttrTypes, actionAttrs)
 		diags.Append(respDiags...)

--- a/internal/resource/config/authenticationpolicies/authentication_policies_resource.go
+++ b/internal/resource/config/authenticationpolicies/authentication_policies_resource.go
@@ -198,7 +198,7 @@ func readAuthenticationPoliciesResponse(ctx context.Context, r *client.Authentic
 			authenticationApiApplicationRef, respDiags := resourcelink.ToState(ctx, authnSelectionTree.AuthenticationApiApplicationRef)
 			diags.Append(respDiags...)
 
-			rootNode, respDiags := authenticationpolicytreenode.ToState(ctx, &authnSelectionTree.RootNode)
+			rootNode, respDiags := authenticationpolicytreenode.ToStateNoValueDefault(ctx, &authnSelectionTree.RootNode)
 			diags.Append(respDiags...)
 
 			authnSelectionTreeAttrValues := map[string]attr.Value{


### PR DESCRIPTION
- Coalesce nil to empty string for attribute source field values, for any resources that default the value to empty string. This prevents potential inconsistent value errors when the PF API returns nil after setting a value to empty string
- Add tests for many potential affected types, ported from #591 
- CDI-888