### PR TITLE
Prevent nil pointer panic when reading configuration rows added outside of terraform

### DIFF
--- a/.changelog/pr-603.txt
+++ b/.changelog/pr-603.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed an issue where adding table rows to plugin configuration outside of terraform (such as via the PingFederate UI) could cause a panic when running a subsequent plan.
+```

--- a/internal/acctest/config/passwordcredentialvalidator/password_credential_validator_table_rows_drift_test.go
+++ b/internal/acctest/config/passwordcredentialvalidator/password_credential_validator_table_rows_drift_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2026 Ping Identity Corporation
+
+package passwordcredentialvalidator_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	client "github.com/pingidentity/pingfederate-go-client/v1300/configurationapi"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/provider"
+)
+
+// This test validates that if a row is added to a plugin configuration table outside of Terraform,
+// a non-empty plan is generated reflecting the drift, with no panic or error.
+func TestAccPasswordCredentialValidator_RadiusTableRowsDrift(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: passwordCredentialValidator_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: passwordCredentialValidator_RadiusCompleteHCL(),
+			},
+			{
+				PreConfig: func() {
+					passwordCredentialValidator_AddRadiusServerRow(t)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func passwordCredentialValidator_AddRadiusServerRow(t *testing.T) {
+	testClient := acctest.TestClient()
+	ctx := acctest.TestBasicAuthContext()
+
+	validator, _, err := testClient.PasswordCredentialValidatorsAPI.GetPasswordCredentialValidator(ctx, validatorId).Execute()
+	if err != nil {
+		t.Fatalf("Failed to get password credential validator: %v", err)
+	}
+
+	tableIndex := -1
+	for i, table := range validator.Configuration.Tables {
+		if table.Name == "RADIUS Servers" {
+			tableIndex = i
+			break
+		}
+	}
+
+	if tableIndex < 0 {
+		t.Fatal("Failed to find RADIUS Servers table in password credential validator configuration")
+	}
+
+	newRow := client.ConfigRow{Fields: []client.ConfigField{
+		{Name: "Hostname", Value: client.PtrString("localhost2")},
+		{Name: "Authentication Port", Value: client.PtrString("1812")},
+		{Name: "Authentication Protocol", Value: client.PtrString("PAP")},
+		{Name: "Shared Secret", Value: client.PtrString("mysecret2")},
+	}}
+
+	validator.Configuration.Tables[tableIndex].Rows = append(validator.Configuration.Tables[tableIndex].Rows, newRow)
+
+	updateRequest := testClient.PasswordCredentialValidatorsAPI.UpdatePasswordCredentialValidator(ctx, validatorId)
+	updateRequest = updateRequest.Body(*validator)
+	_, _, err = testClient.PasswordCredentialValidatorsAPI.UpdatePasswordCredentialValidatorExecute(updateRequest)
+	if err != nil {
+		t.Fatalf("Failed to update password credential validator with additional row: %v", err)
+	}
+}

--- a/internal/resource/common/pluginconfiguration/plugin_configuration_state.go
+++ b/internal/resource/common/pluginconfiguration/plugin_configuration_state.go
@@ -245,32 +245,37 @@ func readRowsResponse(rows []client.ConfigRow, planRows *types.List, diags *diag
 			rowsSensitiveFieldsSplit = append(rowsSensitiveFieldsSplit, rowSensitiveFieldsSplit)
 		}
 	} else {
-		// This is assuming there are never any rows added by the PF API. If there
-		// are ever rows added, this will cause a nil pointer exception trying to read
-		// index i of planRowsElements.
 		planRowsElements := planRows.Elements()
 		for i := 0; i < len(rows); i++ {
 			attrValues := map[string]attr.Value{}
 			attrValuesSensitiveSplit := map[string]attr.Value{}
 			attrValues["default_row"] = types.BoolPointerValue(rows[i].DefaultRow)
 			attrValuesSensitiveSplit["default_row"] = types.BoolPointerValue(rows[i].DefaultRow)
-			planRow := planRowsElements[i].(types.Object)
+			rowInPlan := i < len(planRowsElements)
 			var planRowFields, planRowSensitiveFields *types.Set
-			planRowFieldsVal, ok := planRow.Attributes()["fields"]
-			if ok {
-				setVal := planRowFieldsVal.(types.Set)
-				planRowFields = &setVal
-			}
-			planRowSensitiveFieldsVal, ok := planRow.Attributes()["sensitive_fields"]
-			if ok {
-				setVal := planRowSensitiveFieldsVal.(types.Set)
-				planRowSensitiveFields = &setVal
+			if rowInPlan {
+				planRow := planRowsElements[i].(types.Object)
+				planRowFieldsVal, ok := planRow.Attributes()["fields"]
+				if ok {
+					setVal := planRowFieldsVal.(types.Set)
+					planRowFields = &setVal
+				}
+				planRowSensitiveFieldsVal, ok := planRow.Attributes()["sensitive_fields"]
+				if ok {
+					setVal := planRowSensitiveFieldsVal.(types.Set)
+					planRowSensitiveFields = &setVal
+				}
 			}
 
 			rowFields := readFieldsResponse(rows[i].Fields, planRowFields, planRowSensitiveFields, diags)
 			attrValues["fields"] = rowFields.allFields
-			attrValuesSensitiveSplit["fields"] = rowFields.plannedCleartextFields
-			attrValuesSensitiveSplit["sensitive_fields"] = rowFields.plannedSensitiveFields
+			if rowInPlan {
+				attrValuesSensitiveSplit["fields"] = rowFields.plannedCleartextFields
+				attrValuesSensitiveSplit["sensitive_fields"] = rowFields.plannedSensitiveFields
+			} else {
+				attrValuesSensitiveSplit["fields"] = rowFields.allCleartextFields
+				attrValuesSensitiveSplit["sensitive_fields"] = rowFields.allSensitiveFields
+			}
 
 			rowMergedFields, respDiags := types.ObjectValue(rowsMergedFieldsAttrTypes, attrValues)
 			diags.Append(respDiags...)


### PR DESCRIPTION
- Fix potential panic in the provider occurring when table rows were added to plugin configuration outside of terraform (such as in the PingFederate UI)
- Closes #595
- CDI-896