### PR TITLE
(fix)resource/redirect_validation: boolean attributes inside white_list and uri_allow_list sets change on each apply

### DIFF
--- a/.changelog/pr-609.txt
+++ b/.changelog/pr-609.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/pingfederate_redirect_validation`: Updated the `redirect_validation_local_settings.white_list` and `redirect_validation_local_settings.uri_allow_list` fields to be Lists instead of Sets. This change helps prevent errors due to known terraform issues with nested sets. This change will not require any change to existing configuration, but existing state will need to be re-imported. These fields are now ordered instead of unordered, so future changes in ordering in configuration will result in planned changes with terraform.
+```
+
+```release-note:bug
+`resource/pingfederate_redirect_validation`: Fixed an issue where boolean attributes inside `white_list` and `uri_allow_list` entries would appear to flip between plans after each apply. Related to a known terraform-plugin-framework bug with `Default` values in nested set attributes: [#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867).
+```

--- a/.changelog/pr-609.txt
+++ b/.changelog/pr-609.txt
@@ -1,5 +1,5 @@
 ```release-note:breaking-change
-`resource/pingfederate_redirect_validation`: Updated the `redirect_validation_local_settings.white_list` and `redirect_validation_local_settings.uri_allow_list` fields to be Lists instead of Sets. This change helps prevent errors due to known terraform issues with nested sets. This change will not require any change to existing configuration, but existing state will need to be re-imported. These fields are now ordered instead of unordered, so future changes in ordering in configuration will result in planned changes with terraform.
+`resource/pingfederate_redirect_validation`: Updated the `redirect_validation_local_settings.white_list` and `redirect_validation_local_settings.uri_allow_list` fields to be Lists instead of Sets. This change helps prevent errors due to known terraform issues with nested sets. This change will not require any change to existing configuration or state. These fields are now ordered instead of unordered, so future changes in ordering in configuration will result in planned changes with terraform.
 ```
 
 ```release-note:bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Bug fixes
+* Fixed an issue where boolean attributes inside `pingfederate_redirect_validation.redirect_validation_local_settings.white_list` and `uri_allow_list` entries (`target_resource_sso`, `target_resource_slo`, `in_error_resource`, `idp_discovery`, `allow_query_and_fragment`, `require_https`) appeared to flip between plans after each apply. Root cause: a known terraform-plugin-framework bug with `Default` values in nested set attributes ([#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867)) introduced when these attributes were converted to sets in v1.6.2. Converting to ordered lists resolves the issue and restores predictable plan output. ([CDI-1076])
+
 # v1.7.0 February 4, 2026
 ### Enhancements
 * Added support for PingFederate `13.0.0` and implemented new attributes for the new version. Added support for latest PF patch releases to `11.3`, `12.0`, `12.1`, `12.2`, and `12.3`. ([#561]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/561)))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Unreleased
-
-### Bug fixes
-* Fixed an issue where boolean attributes inside `pingfederate_redirect_validation.redirect_validation_local_settings.white_list` and `uri_allow_list` entries (`target_resource_sso`, `target_resource_slo`, `in_error_resource`, `idp_discovery`, `allow_query_and_fragment`, `require_https`) appeared to flip between plans after each apply. Root cause: a known terraform-plugin-framework bug with `Default` values in nested set attributes ([#867](https://github.com/hashicorp/terraform-plugin-framework/issues/867)) introduced when these attributes were converted to sets in v1.6.2. Converting to ordered lists resolves the issue and restores predictable plan output. ([CDI-1076])
-
 # v1.7.0 February 4, 2026
 ### Enhancements
 * Added support for PingFederate `13.0.0` and implemented new attributes for the new version. Added support for latest PF patch releases to `11.3`, `12.0`, `12.1`, `12.2`, and `12.3`. ([#561]([https](https://github.com/pingidentity/terraform-provider-pingfederate/pull/561)))

--- a/docs/data-sources/redirect_validation.md
+++ b/docs/data-sources/redirect_validation.md
@@ -34,8 +34,8 @@ Read-Only:
 - `enable_target_resource_validation_for_idp_discovery` (Boolean) Enable target resource validation for IdP discovery.
 - `enable_target_resource_validation_for_slo` (Boolean) Enable target resource validation for SLO.
 - `enable_target_resource_validation_for_sso` (Boolean) Enable target resource validation for SSO.
-- `uri_allow_list` (Attributes Set) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
-- `white_list` (Attributes Set) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
+- `uri_allow_list` (Attributes List) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
+- `white_list` (Attributes List) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
 
 <a id="nestedatt--redirect_validation_local_settings--uri_allow_list"></a>
 ### Nested Schema for `redirect_validation_local_settings.uri_allow_list`

--- a/docs/resources/redirect_validation.md
+++ b/docs/resources/redirect_validation.md
@@ -74,8 +74,8 @@ Optional:
 - `enable_target_resource_validation_for_idp_discovery` (Boolean) Enable target resource validation for IdP discovery. Defaults to `false`.
 - `enable_target_resource_validation_for_slo` (Boolean) Enable target resource validation for SLO. Defaults to `false`.
 - `enable_target_resource_validation_for_sso` (Boolean) Enable target resource validation for SSO. Defaults to `false`.
-- `uri_allow_list` (Attributes Set) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
-- `white_list` (Attributes Set) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
+- `uri_allow_list` (Attributes List) List of URIs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--uri_allow_list))
+- `white_list` (Attributes List) List of URLs that are designated as valid target resources. (see [below for nested schema](#nestedatt--redirect_validation_local_settings--white_list))
 
 <a id="nestedatt--redirect_validation_local_settings--uri_allow_list"></a>
 ### Nested Schema for `redirect_validation_local_settings.uri_allow_list`
@@ -108,7 +108,7 @@ Optional:
 - `require_https` (Boolean) Require HTTPS for accessing this resource. Defaults to `false`.
 - `target_resource_slo` (Boolean) Enable this target resource for SLO redirect validation. Defaults to `false`.
 - `target_resource_sso` (Boolean) Enable this target resource for SSO redirect validation. Defaults to `false`.
-- `valid_path` (String) Path of a valid resource.
+- `valid_path` (String) Path of a valid resource. Defaults to an empty string.
 
 
 

--- a/internal/acctest/config/redirectvalidation/redirect_validation_resource_gen_test.go
+++ b/internal/acctest/config/redirectvalidation/redirect_validation_resource_gen_test.go
@@ -28,8 +28,9 @@ func TestAccRedirectValidation_MinimalMaximal(t *testing.T) {
 				Check:  redirectValidation_CheckComputedValuesMinimal(),
 			},
 			{
-				// Update to a complete model. No computed values to check.
+				// Update to a complete model; verify list ordering by index
 				Config: redirectValidation_CompleteHCL(),
+				Check:  redirectValidation_CheckComputedValuesComplete(),
 			},
 			{
 				// Test importing the resource
@@ -40,8 +41,20 @@ func TestAccRedirectValidation_MinimalMaximal(t *testing.T) {
 				ImportStateVerify:                    true,
 			},
 			{
-				// Reorder values in the complete model
+				// Reorder values in the complete model; list ordering should change in state
 				Config: redirectValidation_CompleteHCLReordered(),
+				Check:  redirectValidation_CheckComputedValuesReordered(),
+			},
+			{
+				// Regression for CDI-1076: white_list entries with mixed boolean values
+				// must not flip back-and-forth between plans. Verify values at each index.
+				Config: redirectValidation_MixedBoolsHCL(),
+				Check:  redirectValidation_CheckComputedValuesMixedBools(),
+			},
+			{
+				// Re-apply the same mixed-bool config to confirm a clean plan
+				Config:   redirectValidation_MixedBoolsHCL(),
+				PlanOnly: true,
 			},
 			{
 				// Back to minimal model
@@ -195,6 +208,65 @@ data "pingfederate_redirect_validation" "example" {
 `, versionedHcl)
 }
 
+// HCL with white_list entries that mix true and false boolean values.
+// Used to guard against the regression where Set element defaults caused booleans to
+// flip between plans (CDI-1076).
+func redirectValidation_MixedBoolsHCL() string {
+	versionedHcl := ""
+	if acctest.VersionAtLeast(version.PingFederate1210) {
+		versionedHcl += `
+    uri_allow_list = [
+      {
+        target_resource_sso      = true
+        target_resource_slo      = false
+        in_error_resource        = true
+        idp_discovery            = false
+        allow_query_and_fragment = false
+        valid_uri                = "https://mixed.example.com"
+      },
+    ]
+		`
+	}
+	return fmt.Sprintf(`
+resource "pingfederate_redirect_validation" "example" {
+  redirect_validation_local_settings = {
+    enable_in_error_resource_validation                 = true
+    enable_target_resource_validation_for_idp_discovery = false
+    enable_target_resource_validation_for_slo           = true
+    enable_target_resource_validation_for_sso           = false
+    white_list = [
+      {
+        allow_query_and_fragment = false
+        idp_discovery            = true
+        in_error_resource        = false
+        require_https            = true
+        target_resource_slo      = false
+        target_resource_sso      = true
+        valid_domain             = "mixed.example.com"
+        valid_path               = "/mixed"
+      },
+      {
+        allow_query_and_fragment = true
+        idp_discovery            = false
+        in_error_resource        = true
+        require_https            = false
+        target_resource_slo      = true
+        target_resource_sso      = false
+        valid_domain             = "another.example.com"
+      },
+    ]
+	%s
+  }
+  redirect_validation_partner_settings = {
+    enable_wreply_validation_slo = true
+  }
+}
+data "pingfederate_redirect_validation" "example" {
+  depends_on = [pingfederate_redirect_validation.example]
+}
+`, versionedHcl)
+}
+
 // Validate any computed values when applying minimal HCL
 func redirectValidation_CheckComputedValuesMinimal() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
@@ -206,4 +278,85 @@ func redirectValidation_CheckComputedValuesMinimal() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "0"),
 		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_partner_settings.enable_wreply_validation_slo", "false"),
 	)
+}
+
+// Validate list ordering after applying complete HCL: entry 0 = example.com, entry 1 = second.example.com
+func redirectValidation_CheckComputedValuesComplete() resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "2"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_domain", "example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_path", "/path"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.target_resource_sso", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.require_https", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_domain", "second.example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_path", "/second/path"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.target_resource_sso", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.require_https", "true"),
+	}
+	if acctest.VersionAtLeast(version.PingFederate1210) {
+		checks = append(checks,
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.#", "2"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.valid_uri", "https://example.com"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.1.valid_uri", "https://anotherone.example.com"),
+		)
+	}
+	return resource.ComposeTestCheckFunc(checks...)
+}
+
+// Validate list ordering after reordering: entry 0 = second.example.com, entry 1 = example.com
+// This confirms the list preserves insertion order rather than normalizing like a set would.
+func redirectValidation_CheckComputedValuesReordered() resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "2"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_domain", "second.example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_path", "/second/path"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_domain", "example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_path", "/path"),
+	}
+	if acctest.VersionAtLeast(version.PingFederate1210) {
+		checks = append(checks,
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.#", "2"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.valid_uri", "https://anotherone.example.com"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.1.valid_uri", "https://example.com"),
+		)
+	}
+	return resource.ComposeTestCheckFunc(checks...)
+}
+
+// Validate CDI-1076 regression: mixed true/false booleans are stored correctly at each index
+// and do not get defaulted to false by the framework between applies.
+func redirectValidation_CheckComputedValuesMixedBools() resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "2"),
+		// Entry 0: mixed.example.com — sso=true, slo=false, in_error=false, idp=true, query=false, https=true
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_domain", "mixed.example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.target_resource_sso", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.target_resource_slo", "false"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.in_error_resource", "false"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.idp_discovery", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.allow_query_and_fragment", "false"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.require_https", "true"),
+		// Entry 1: another.example.com — sso=false, slo=true, in_error=true, idp=false, query=true, https=false
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_domain", "another.example.com"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.target_resource_sso", "false"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.target_resource_slo", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.in_error_resource", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.idp_discovery", "false"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.allow_query_and_fragment", "true"),
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.require_https", "false"),
+		// valid_path defaults to "" when omitted
+		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_path", ""),
+	}
+	if acctest.VersionAtLeast(version.PingFederate1210) {
+		checks = append(checks,
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.#", "1"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.valid_uri", "https://mixed.example.com"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.target_resource_sso", "true"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.target_resource_slo", "false"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.in_error_resource", "true"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.idp_discovery", "false"),
+			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.allow_query_and_fragment", "false"),
+		)
+	}
+	return resource.ComposeTestCheckFunc(checks...)
 }

--- a/internal/acctest/config/redirectvalidation/redirect_validation_resource_gen_test.go
+++ b/internal/acctest/config/redirectvalidation/redirect_validation_resource_gen_test.go
@@ -28,9 +28,8 @@ func TestAccRedirectValidation_MinimalMaximal(t *testing.T) {
 				Check:  redirectValidation_CheckComputedValuesMinimal(),
 			},
 			{
-				// Update to a complete model; verify list ordering by index
+				// Update to a complete model. No computed values to check.
 				Config: redirectValidation_CompleteHCL(),
-				Check:  redirectValidation_CheckComputedValuesComplete(),
 			},
 			{
 				// Test importing the resource
@@ -278,29 +277,6 @@ func redirectValidation_CheckComputedValuesMinimal() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "0"),
 		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_partner_settings.enable_wreply_validation_slo", "false"),
 	)
-}
-
-// Validate list ordering after applying complete HCL: entry 0 = example.com, entry 1 = second.example.com
-func redirectValidation_CheckComputedValuesComplete() resource.TestCheckFunc {
-	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.#", "2"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_domain", "example.com"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.valid_path", "/path"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.target_resource_sso", "true"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.0.require_https", "true"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_domain", "second.example.com"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.valid_path", "/second/path"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.target_resource_sso", "true"),
-		resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.white_list.1.require_https", "true"),
-	}
-	if acctest.VersionAtLeast(version.PingFederate1210) {
-		checks = append(checks,
-			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.#", "2"),
-			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.0.valid_uri", "https://example.com"),
-			resource.TestCheckResourceAttr("pingfederate_redirect_validation.example", "redirect_validation_local_settings.uri_allow_list.1.valid_uri", "https://anotherone.example.com"),
-		)
-	}
-	return resource.ComposeTestCheckFunc(checks...)
 }
 
 // Validate list ordering after reordering: entry 0 = second.example.com, entry 1 = example.com

--- a/internal/resource/config/redirectvalidation/redirect_validation_data_source.go
+++ b/internal/resource/config/redirectvalidation/redirect_validation_data_source.go
@@ -59,7 +59,7 @@ func (r *redirectValidationDataSource) Schema(ctx context.Context, req datasourc
 						Computed:    true,
 						Optional:    false,
 					},
-					"white_list": schema.SetNestedAttribute{
+					"white_list": schema.ListNestedAttribute{
 						Description: "List of URLs that are designated as valid target resources.",
 						Computed:    true,
 						Optional:    false,
@@ -108,7 +108,7 @@ func (r *redirectValidationDataSource) Schema(ctx context.Context, req datasourc
 							},
 						},
 					},
-					"uri_allow_list": schema.SetNestedAttribute{
+					"uri_allow_list": schema.ListNestedAttribute{
 						Description: "List of URIs that are designated as valid target resources.",
 						Computed:    true,
 						Optional:    false,

--- a/internal/resource/config/redirectvalidation/redirect_validation_resource.go
+++ b/internal/resource/config/redirectvalidation/redirect_validation_resource.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -56,22 +56,22 @@ var (
 		"enable_target_resource_validation_for_slo":           types.BoolType,
 		"enable_target_resource_validation_for_idp_discovery": types.BoolType,
 		"enable_in_error_resource_validation":                 types.BoolType,
-		"white_list":                                          types.SetType{ElemType: types.ObjectType{AttrTypes: whiteListAttrTypes}},
-		"uri_allow_list":                                      types.SetType{ElemType: types.ObjectType{AttrTypes: uriAllowListAttrTypes}},
+		"white_list":                                          types.ListType{ElemType: types.ObjectType{AttrTypes: whiteListAttrTypes}},
+		"uri_allow_list":                                      types.ListType{ElemType: types.ObjectType{AttrTypes: uriAllowListAttrTypes}},
 	}
 
 	redirectValidationPartnerSettingsAttrTypes = map[string]attr.Type{
 		"enable_wreply_validation_slo": types.BoolType,
 	}
 
-	whiteListDefault, _                       = types.SetValue(types.ObjectType{AttrTypes: whiteListAttrTypes}, nil)
+	whiteListDefault, _                       = types.ListValue(types.ObjectType{AttrTypes: whiteListAttrTypes}, nil)
 	redirectValidationLocalSettingsDefault, _ = types.ObjectValue(redirectValidationLocalSettingsAttrTypes, map[string]attr.Value{
 		"enable_target_resource_validation_for_sso":           types.BoolValue(false),
 		"enable_target_resource_validation_for_slo":           types.BoolValue(false),
 		"enable_target_resource_validation_for_idp_discovery": types.BoolValue(false),
 		"enable_in_error_resource_validation":                 types.BoolValue(false),
 		"white_list":                                          whiteListDefault,
-		"uri_allow_list":                                      types.SetNull(types.ObjectType{AttrTypes: uriAllowListAttrTypes}),
+		"uri_allow_list":                                      types.ListNull(types.ObjectType{AttrTypes: uriAllowListAttrTypes}),
 	})
 
 	redirectValidationPartnerSettingsDefault, _ = types.ObjectValue(redirectValidationPartnerSettingsAttrTypes, map[string]attr.Value{
@@ -125,35 +125,35 @@ func (r *redirectValidationResource) Schema(ctx context.Context, req resource.Sc
 						Optional:    true,
 						Default:     booldefault.StaticBool(false),
 					},
-					"white_list": schema.SetNestedAttribute{
+					"white_list": schema.ListNestedAttribute{
 						Description: "List of URLs that are designated as valid target resources.",
 						Computed:    true,
 						Optional:    true,
-						Default:     setdefault.StaticValue(whiteListDefault),
+						Default:     listdefault.StaticValue(whiteListDefault),
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"target_resource_sso": schema.BoolAttribute{
 									Description: "Enable this target resource for SSO redirect validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"target_resource_slo": schema.BoolAttribute{
 									Description: "Enable this target resource for SLO redirect validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"in_error_resource": schema.BoolAttribute{
 									Description: "Enable this target resource for in error resource validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"idp_discovery": schema.BoolAttribute{
 									Description: "Enable this target resource for IdP discovery validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"valid_domain": schema.StringAttribute{
@@ -164,27 +164,27 @@ func (r *redirectValidationResource) Schema(ctx context.Context, req resource.Sc
 									},
 								},
 								"valid_path": schema.StringAttribute{
-									Description: "Path of a valid resource.",
-									Computed:    true,
+									Description: "Path of a valid resource. Defaults to an empty string.",
 									Optional:    true,
+									Computed:    true,
 									Default:     stringdefault.StaticString(""),
 								},
 								"allow_query_and_fragment": schema.BoolAttribute{
 									Description: "Allow any query parameters and fragment in the resource. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"require_https": schema.BoolAttribute{
 									Description: "Require HTTPS for accessing this resource. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 							},
 						},
 					},
-					"uri_allow_list": schema.SetNestedAttribute{
+					"uri_allow_list": schema.ListNestedAttribute{
 						Description: "List of URIs that are designated as valid target resources.",
 						Optional:    true,
 						Computed:    true,
@@ -192,32 +192,32 @@ func (r *redirectValidationResource) Schema(ctx context.Context, req resource.Sc
 							Attributes: map[string]schema.Attribute{
 								"target_resource_sso": schema.BoolAttribute{
 									Description: "Enable this target resource for SSO redirect validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"target_resource_slo": schema.BoolAttribute{
 									Description: "Enable this target resource for SLO redirect validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"in_error_resource": schema.BoolAttribute{
 									Description: "Enable this target resource for in error resource validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"idp_discovery": schema.BoolAttribute{
 									Description: "Enable this target resource for IdP discovery validation. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"allow_query_and_fragment": schema.BoolAttribute{
 									Description: "Allow any query parameters and fragment in the resource. Defaults to `false`.",
-									Computed:    true,
 									Optional:    true,
+									Computed:    true,
 									Default:     booldefault.StaticBool(false),
 								},
 								"valid_uri": schema.StringAttribute{
@@ -276,7 +276,7 @@ func (r *redirectValidationResource) ModifyPlan(ctx context.Context, req resourc
 				version.AddUnsupportedAttributeError("redirect_validation_local_settings.uri_allow_list",
 					r.providerConfig.ProductVersion, version.PingFederate1210, &resp.Diagnostics)
 			} else if uriAllowList.IsUnknown() {
-				localSettingsAttrs["uri_allow_list"] = types.SetNull(types.ObjectType{AttrTypes: uriAllowListAttrTypes})
+				localSettingsAttrs["uri_allow_list"] = types.ListNull(types.ObjectType{AttrTypes: uriAllowListAttrTypes})
 				localSettingsModified = true
 			}
 		}
@@ -284,7 +284,7 @@ func (r *redirectValidationResource) ModifyPlan(ctx context.Context, req resourc
 		localSettingsAttrs = plan.RedirectValidationLocalSettings.Attributes()
 		if localSettingsAttrs["uri_allow_list"].IsUnknown() {
 			// Default to empty list
-			localSettingsAttrs["uri_allow_list"], diags = types.SetValue(types.ObjectType{AttrTypes: uriAllowListAttrTypes}, nil)
+			localSettingsAttrs["uri_allow_list"], diags = types.ListValue(types.ObjectType{AttrTypes: uriAllowListAttrTypes}, nil)
 			resp.Diagnostics.Append(diags...)
 			localSettingsModified = true
 		}
@@ -308,7 +308,7 @@ func addOptionalRedirectValidationFields(addRequest *client.RedirectValidationSe
 		redirectValidationLocalSettingsValue.EnableTargetResourceValidationForSSO = redirectValidationLocalSettingsAttrs["enable_target_resource_validation_for_sso"].(types.Bool).ValueBoolPointer()
 		if !redirectValidationLocalSettingsAttrs["uri_allow_list"].IsNull() && !redirectValidationLocalSettingsAttrs["uri_allow_list"].IsUnknown() {
 			redirectValidationLocalSettingsValue.UriAllowList = []client.RedirectValidationSettingsUriAllowlistEntry{}
-			for _, uriAllowListElement := range redirectValidationLocalSettingsAttrs["uri_allow_list"].(types.Set).Elements() {
+			for _, uriAllowListElement := range redirectValidationLocalSettingsAttrs["uri_allow_list"].(types.List).Elements() {
 				uriAllowListValue := client.RedirectValidationSettingsUriAllowlistEntry{}
 				uriAllowListAttrs := uriAllowListElement.(types.Object).Attributes()
 				uriAllowListValue.AllowQueryAndFragment = uriAllowListAttrs["allow_query_and_fragment"].(types.Bool).ValueBoolPointer()
@@ -322,7 +322,7 @@ func addOptionalRedirectValidationFields(addRequest *client.RedirectValidationSe
 		}
 		if !redirectValidationLocalSettingsAttrs["white_list"].IsNull() && !redirectValidationLocalSettingsAttrs["white_list"].IsUnknown() {
 			redirectValidationLocalSettingsValue.WhiteList = []client.RedirectValidationSettingsWhitelistEntry{}
-			for _, whiteListElement := range redirectValidationLocalSettingsAttrs["white_list"].(types.Set).Elements() {
+			for _, whiteListElement := range redirectValidationLocalSettingsAttrs["white_list"].(types.List).Elements() {
 				whiteListValue := client.RedirectValidationSettingsWhitelistEntry{}
 				whiteListAttrs := whiteListElement.(types.Object).Attributes()
 				whiteListValue.AllowQueryAndFragment = whiteListAttrs["allow_query_and_fragment"].(types.Bool).ValueBoolPointer()


### PR DESCRIPTION
Change white_list and uri_allow_list from Set to List in redirect_validation resource

Fixes CDI-1076: boolean attributes inside white_list and uri_allow_list set entries were flipping between plans due to a known terraform-plugin-framework bug where Default values on nested set attributes cause element hashes to change each cycle. Converting to ordered lists resolves the flipping and restores Default values on nested attributes for proper zero-value handling. Adds index-based test assertions to cover list ordering and the CDI-1076 regression.