### PR TITLE
Remove PF test matrix for archived docker image, bump other PF patches

### DIFF
--- a/.github/workflows/scheduled-acctests.yaml
+++ b/.github/workflows/scheduled-acctests.yaml
@@ -17,9 +17,9 @@ jobs:
           - "1.11.*"
         # Cover newest patch release of the major-minor releases we support
         pingfederate:
-          - "12.2.6"
-          - "12.3.6"
-          - "13.0.3"
+          - "12.2.4"
+          - "12.3.0"
+          - "13.0.0"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6

--- a/.github/workflows/scheduled-acctests.yaml
+++ b/.github/workflows/scheduled-acctests.yaml
@@ -17,10 +17,9 @@ jobs:
           - "1.11.*"
         # Cover newest patch release of the major-minor releases we support
         pingfederate:
-          - "12.1.8"
-          - "12.2.4"
-          - "12.3.0"
-          - "13.0.0"
+          - "12.2.6"
+          - "12.3.6"
+          - "13.0.3"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6


### PR DESCRIPTION
- Remove 12.1 branch from acceptance tests, not stable tags available on docker hub
- Patch versions of other test targets will be updated when we add pf 13.1