### PR TITLE
fix(oauth_access_token_manager): make sequence_number configurable

### DIFF
--- a/.changelog/pr-634.txt
+++ b/.changelog/pr-634.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingfederate_oauth_access_token_manager`: Fixed an issue where `sequence_number` could not be configured. The attribute is now Optional in addition to Computed, allowing the sequence number (embedded in the `pi.atm` claim of issued access tokens) to be pinned to a specific value. If not configured, a server-assigned value is used, and the previously-assigned value is retained if the attribute is later removed from configuration.
+```

--- a/docs/resources/oauth_access_token_manager.md
+++ b/docs/resources/oauth_access_token_manager.md
@@ -285,13 +285,13 @@ resource "pingfederate_oauth_access_token_manager" "jwt_example" {
 - `access_control_settings` (Attributes) Settings which determine which clients may access this token manager. (see [below for nested schema](#nestedatt--access_control_settings))
 - `parent_ref` (Attributes) The reference to this plugin's parent instance. The parent reference is only accepted if the plugin type supports parent instances. Note: This parent reference is required if this plugin instance is used as an overriding plugin (e.g. connection adapter overrides) (see [below for nested schema](#nestedatt--parent_ref))
 - `selection_settings` (Attributes) Settings which determine how this token manager can be selected for use by an OAuth request. (see [below for nested schema](#nestedatt--selection_settings))
+- `sequence_number` (Number) Number added to an access token to identify which Access Token Manager issued the token.
 - `session_validation_settings` (Attributes) Settings which determine how the user session is associated with the access token. (see [below for nested schema](#nestedatt--session_validation_settings))
 - `token_endpoint_attribute_contract` (Attributes) A set of attributes exposed by an Access Token Manager in a token endpoint response. (see [below for nested schema](#nestedatt--token_endpoint_attribute_contract))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `sequence_number` (Number) Number added to an access token to identify which Access Token Manager issued the token.
 
 <a id="nestedatt--attribute_contract"></a>
 ### Nested Schema for `attribute_contract`

--- a/internal/acctest/config/oauth/accesstokenmanager/internally_managed_reference_oauth_access_token_manager_resource_gen_test.go
+++ b/internal/acctest/config/oauth/accesstokenmanager/internally_managed_reference_oauth_access_token_manager_resource_gen_test.go
@@ -87,6 +87,57 @@ func TestAccOauthAccessTokenManager_MinimalMaximalInternallyManaged(t *testing.T
 	})
 }
 
+func TestAccOauthAccessTokenManager_SequenceNumber(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		CheckDestroy: oauthAccessTokenManager_CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create with an explicitly configured sequence number
+				Config: oauthAccessTokenManager_MinimalInternallyManagedHCLWithSequenceNumber(123456, "seqATM"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_access_token_manager.example", "sequence_number", "123456"),
+				),
+			},
+			{
+				// Update the sequence number to a different explicit value
+				Config: oauthAccessTokenManager_MinimalInternallyManagedHCLWithSequenceNumber(654321, "seqATM"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_access_token_manager.example", "sequence_number", "654321"),
+				),
+			},
+			{
+				// Remove sequence_number from the configuration and change the name (the name
+				// change ensures the update path runs); the previously assigned value must persist
+				Config: oauthAccessTokenManager_MinimalInternallyManagedHCL(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_access_token_manager.example", "sequence_number", "654321"),
+				),
+			},
+			{
+				// Apply the complete configuration (also no sequence_number); the previously
+				// assigned value must still persist
+				Config: oauthAccessTokenManager_CompleteInternallyManagedHCL(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("pingfederate_oauth_access_token_manager.example", "sequence_number", "654321"),
+				),
+			},
+			{
+				// Import to verify the sequence number persisted on the service
+				Config:                               oauthAccessTokenManager_CompleteInternallyManagedHCL(),
+				ResourceName:                         "pingfederate_oauth_access_token_manager.example",
+				ImportStateId:                        atmId,
+				ImportStateVerifyIdentifierAttribute: "manager_id",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+		},
+	})
+}
+
 // Minimal HCL with only required values set
 func oauthAccessTokenManager_MinimalInternallyManagedHCL() string {
 	return fmt.Sprintf(`
@@ -111,6 +162,33 @@ data "pingfederate_oauth_access_token_manager" "example" {
   manager_id = pingfederate_oauth_access_token_manager.example.id
 }
 `, atmId)
+}
+
+// Minimal HCL with an explicitly configured sequence number
+func oauthAccessTokenManager_MinimalInternallyManagedHCLWithSequenceNumber(sequenceNumber int, name string) string {
+	return fmt.Sprintf(`
+resource "pingfederate_oauth_access_token_manager" "example" {
+  manager_id = "%s"
+  configuration = {
+  }
+  name = "%s"
+  plugin_descriptor_ref = {
+    id = "org.sourceid.oauth20.token.plugin.impl.ReferenceBearerAccessTokenManagementPlugin"
+  }
+  attribute_contract = {
+    coreAttributes = []
+    extended_attributes = [
+      {
+        name = "extended_contract"
+      }
+    ]
+  }
+  sequence_number = %d
+}
+data "pingfederate_oauth_access_token_manager" "example" {
+  manager_id = pingfederate_oauth_access_token_manager.example.id
+}
+`, atmId, name, sequenceNumber)
 }
 
 // Maximal HCL with all values set where possible

--- a/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource_gen.go
+++ b/internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource_gen.go
@@ -270,6 +270,7 @@ func (r *oauthAccessTokenManagerResource) Schema(ctx context.Context, req resour
 				Description: "Settings which determine how this token manager can be selected for use by an OAuth request.",
 			},
 			"sequence_number": schema.Int64Attribute{
+				Optional:    true,
 				Computed:    true,
 				Description: "Number added to an access token to identify which Access Token Manager issued the token.",
 				PlanModifiers: []planmodifier.Int64{


### PR DESCRIPTION
Fixes CDI-1452

## Summary

`sequence_number` on `pingfederate_oauth_access_token_manager` was defined as `Computed`-only, so Terraform could not set it — even though the PingFederate Admin API accepts `sequenceNumber` on both POST and PUT. Sequence numbers identify which token manager issued a token (embedded in the `pi.atm` JWT header claim), so customers managing token managers declaratively across Dev/Staging/Prod need to pin them to avoid drift and token-validation failures.

## Changes

- `internal/resource/config/oauth/accesstokenmanager/oauth_access_token_manager_resource_gen.go`: `sequence_number` is now `Optional` in addition to `Computed`. No validator is added — the API documents no constraint on the field, and the provider's convention is to add plan-time validators only where the API documents a bound (all 38 existing `int64validator` usages map to a documented bound; the ~180 other int attributes are unvalidated). Values outside the server's accepted range are rejected by PingFederate with a 422. The existing `UseNonNullStateForUnknown` plan modifier is unchanged, so removing the attribute from configuration retains the previously assigned value instead of diffing.
- Acceptance test `TestAccOauthAccessTokenManager_SequenceNumber`: create pinned (`123456`) → update (`654321`) → remove from config (with a name change so the update path runs) and verify the value persists → full config reshape still persists → import-verify.
- Regenerated `docs/resources/oauth_access_token_manager.md` (`sequence_number` moves Read-Only → Optional). Data-source doc intentionally unchanged.

## API evidence (live PF 13.1)

Captured in `scratch/cdi-1452-sequence-number/` (untracked):

| Call | Response `sequenceNumber` |
|---|---|
| POST with `424242` | `424242` (echoed) |
| PUT with `424243` | `424243` (echoed) |
| PUT omitting the field | prior value `424243` preserved |
| POST omitting the field | server-assigned random (`1429725`) |

The echo confirms Create/Update can set state from the write-response body — no GET-after-write needed. The OpenAPI spec declares the field `integer/int32` with no `readOnly` annotation and no constraints.

## Validation

- `go build ./...`, `go vet`, `golangci-lint`, `tfproviderlint`, `tflint`, `verifycontent` all pass
- Full ATM acceptance suite passes against PF 13.1 (`RemovalDrift`, `MinimalMaximalInternallyManaged`, `SequenceNumber`, `MinimalMaximalJsonWeb`); `TestAccOauthAccessTokenManagerSettings_MinimalMaximal` passes when run in isolation (pre-existing ordering sensitivity, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)