### PR TITLE
CDI-1474: Add validators to prevent inconsistent result errors

### DIFF
--- a/.changelog/pr-635.txt
+++ b/.changelog/pr-635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Added validation to prevent inconsistent result errors due to empty `expression_criteria` and trailing newlines for `EXPRESSION` values in `attribute_contract_fulfillment`
+```

--- a/.changelog/pr-TBD.txt
+++ b/.changelog/pr-TBD.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-Added new validation to prevent two "Provider produced inconsistent result after apply" errors: (1) `issuance_criteria.expression_criteria` now must contain at least one element if specified, as the API treats an empty `expression_criteria` as equivalent to `null`. (2) `attribute_contract_fulfillment` `value` must no longer end in a trailing newline when `source.type` is `EXPRESSION` — the PingFederate admin API trims trailing newlines from OGNL expressions, which causes inconsistent result errors for values written using Terraform heredoc (`<<-EOT`) syntax.
-```

--- a/.changelog/pr-TBD.txt
+++ b/.changelog/pr-TBD.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Added new validation to prevent two "Provider produced inconsistent result after apply" errors: (1) `issuance_criteria.expression_criteria` now must contain at least one element if specified, as the API treats an empty `expression_criteria` as equivalent to `null`. (2) `attribute_contract_fulfillment` `value` must no longer end in a trailing newline when `source.type` is `EXPRESSION` — the PingFederate admin API trims trailing newlines from OGNL expressions, which causes inconsistent result errors for values written using Terraform heredoc (`<<-EOT`) syntax.
+```

--- a/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_validation_test.go
+++ b/internal/acctest/config/sp/idpconnection/sp_idp_connection_resource_gen_validation_test.go
@@ -1,0 +1,136 @@
+// Copyright © 2026 Ping Identity Corporation
+
+package resource_sp_idp_connection_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/acctest/common/accesstokenmanager"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/provider"
+)
+
+// Reproduces CDI-1474: an empty issuance_criteria.expression_criteria set caused a
+// "Provider produced inconsistent result after apply" error, since the PingFederate admin
+// API omits an empty expressionCriteria element rather than returning it as an empty list.
+func TestAccSpIdpConnection_ExpressionCriteriaEmptySetInvalid(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      spIdpConnection_ExpressionCriteriaEmptySetInvalidHCL(),
+				ExpectError: regexp.MustCompile(`set must contain at least 1 elements`),
+			},
+		},
+	})
+}
+
+func spIdpConnection_ExpressionCriteriaEmptySetInvalidHCL() string {
+	return fmt.Sprintf(`
+%s
+
+resource "pingfederate_sp_idp_connection" "example" {
+  connection_id = "expressioncriteriaemptyconn"
+  credentials = {
+  }
+  entity_id = "docker"
+  idp_oauth_grant_attribute_mapping = {
+    access_token_manager_mappings = [
+      {
+        access_token_manager_ref = {
+          id = pingfederate_oauth_access_token_manager.idpConnValidationAtm.id
+        }
+        attribute_contract_fulfillment = {
+          Username = {
+            source = {
+              type = "ASSERTION"
+            }
+            value = "TOKEN_SUBJECT"
+          }
+        }
+        issuance_criteria = {
+          expression_criteria = []
+        }
+      },
+    ]
+    idp_oauth_attribute_contract = {
+    }
+  }
+  name = "docker"
+}
+`, accesstokenmanager.AccessTokenManagerTestHCL("idpConnValidationAtm"))
+}
+
+// Reproduces CDI-1474: an EXPRESSION-type attribute_contract_fulfillment value written with
+// Terraform heredoc syntax (<<-EOT) ends in a trailing newline, which the PingFederate admin
+// API trims when parsing the OGNL expression, causing a "Provider produced inconsistent result
+// after apply" error.
+func TestAccSpIdpConnection_AttributeContractFulfillmentTrailingNewlineInvalid(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.ConfigurationPreCheck(t) },
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"pingfederate": providerserver.NewProtocol6WithError(provider.NewTestProvider()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      spIdpConnection_AttributeContractFulfillmentTrailingNewlineInvalidHCL(),
+				ExpectError: regexp.MustCompile(`must not end in a trailing newline`),
+			},
+		},
+	})
+}
+
+func spIdpConnection_AttributeContractFulfillmentTrailingNewlineInvalidHCL() string {
+	return fmt.Sprintf(`
+%s
+
+resource "pingfederate_sp_idp_connection" "example" {
+  connection_id = "acftrailingnewlineconn"
+  credentials = {
+  }
+  entity_id = "docker"
+  idp_oauth_grant_attribute_mapping = {
+    access_token_manager_mappings = [
+      {
+        access_token_manager_ref = {
+          id = pingfederate_oauth_access_token_manager.idpConnValidationAtm.id
+        }
+        attribute_contract_fulfillment = {
+          Username = {
+            source = {
+              type = "ASSERTION"
+            }
+            value = "TOKEN_SUBJECT"
+          }
+          aud = {
+            source = {
+              type = "EXPRESSION"
+            }
+            value = <<-EOT
+              #this.get("context.HttpRequest").getObjectValue().getParameter("resource")
+            EOT
+          }
+        }
+      },
+    ]
+    idp_oauth_attribute_contract = {
+      extended_attributes = [
+        {
+          masked = false
+          name   = "aud"
+        },
+      ]
+    }
+  }
+  name = "docker"
+}
+`, accesstokenmanager.AccessTokenManagerTestHCL("idpConnValidationAtm"))
+}

--- a/internal/resource/common/issuancecriteria/issuance_criteria_schema.go
+++ b/internal/resource/common/issuancecriteria/issuance_criteria_schema.go
@@ -3,6 +3,7 @@
 package issuancecriteria
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -67,6 +68,10 @@ func ToSchema() schema.SingleNestedAttribute {
 			"expression_criteria": schema.SetNestedAttribute{
 				Description: "A list of expression issuance criteria where the OGNL expressions must evaluate to true in order for the transaction to continue. Expressions must be enabled in PingFederate to use expression criteria.",
 				Optional:    true,
+				// The PingFederate API treats an empty expression_criteria set as equivalent to null
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"expression": schema.StringAttribute{

--- a/internal/resource/common/policyaction/policy_action_schema.go
+++ b/internal/resource/common/policyaction/policy_action_schema.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/issuancecriteria"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/resourcelink"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/sourcetypeidkey"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/configvalidators"
 )
 
 // Common schema across all policy actions
@@ -216,6 +217,9 @@ func fragmentPolicyActionSchema(includeValueDefault bool) schema.SingleNestedAtt
 							Description: "The value for this attribute.",
 						},
 					},
+				},
+				Validators: []validator.Map{
+					configvalidators.ValidAttributeContractFulfillment(),
 				},
 			},
 			"attribute_sources": attributeSourcesAttr(includeValueDefault),

--- a/internal/resource/config/oauth/accesstokenmapping/oauth_access_token_mapping_resource.go
+++ b/internal/resource/config/oauth/accesstokenmapping/oauth_access_token_mapping_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/resourcelink"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/common/sourcetypeidkey"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/config"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/configvalidators"
 	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/providererror"
 	internaltypes "github.com/pingidentity/terraform-provider-pingfederate/internal/types"
 )
@@ -110,6 +111,9 @@ func (r *oauthAccessTokenMappingResource) Schema(ctx context.Context, req resour
 							Default:     stringdefault.StaticString(""),
 						},
 					},
+				},
+				Validators: []validator.Map{
+					configvalidators.ValidAttributeContractFulfillment(),
 				},
 			},
 			"issuance_criteria": issuancecriteria.ToSchema(),

--- a/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
+++ b/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
@@ -2350,6 +2350,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 								Required:            true,
 								Description:         "A list of mappings from attribute names to their fulfillment values.",
 								MarkdownDescription: "A list of mappings from attribute names to their fulfillment values.",
+								Validators: []validator.Map{
+									configvalidators.ValidAttributeContractFulfillment(),
+								},
 							},
 							"attribute_sources": attributesources.ToSchema(0, false),
 							"issuance_criteria": issuancecriteria.ToSchema(),
@@ -2513,6 +2516,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 									Required:            true,
 									Description:         "A list of mappings from attribute names to their fulfillment values.",
 									MarkdownDescription: "A list of mappings from attribute names to their fulfillment values.",
+									Validators: []validator.Map{
+										configvalidators.ValidAttributeContractFulfillment(),
+									},
 								},
 								"attribute_sources": attributesources.ToSchema(0, false),
 								"issuance_criteria": issuancecriteria.ToSchema(),
@@ -3673,6 +3679,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 									Required:            true,
 									Description:         "A list of mappings from attribute names to their fulfillment values.",
 									MarkdownDescription: "A list of mappings from attribute names to their fulfillment values.",
+									Validators: []validator.Map{
+										configvalidators.ValidAttributeContractFulfillment(),
+									},
 								},
 								"attribute_sources": attributesources.ToSchema(0, false),
 								"default_mapping": schema.BoolAttribute{

--- a/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
+++ b/internal/resource/config/sp/idpconnection/sp_idp_connection_resource.go
@@ -3008,6 +3008,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 										Required:            true,
 										Description:         "A list of user repository mappings from attribute names to their fulfillment values.",
 										MarkdownDescription: "A list of user repository mappings from attribute names to their fulfillment values.",
+										Validators: []validator.Map{
+											configvalidators.ValidAttributeContractFulfillment(),
+										},
 									},
 									"attributes": schema.SetNestedAttribute{
 										NestedObject: schema.NestedAttributeObject{
@@ -3105,6 +3108,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 										Required:            true,
 										Description:         "A list of user repository mappings from attribute names to their fulfillment values.",
 										MarkdownDescription: "A list of user repository mappings from attribute names to their fulfillment values.",
+										Validators: []validator.Map{
+											configvalidators.ValidAttributeContractFulfillment(),
+										},
 									},
 								},
 								Required:            true,
@@ -3341,6 +3347,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 										Required:            true,
 										Description:         "A list of user repository mappings from attribute names to their fulfillment values.",
 										MarkdownDescription: "A list of user repository mappings from attribute names to their fulfillment values.",
+										Validators: []validator.Map{
+											configvalidators.ValidAttributeContractFulfillment(),
+										},
 									},
 									"attributes": schema.SetNestedAttribute{
 										NestedObject: schema.NestedAttributeObject{
@@ -3438,6 +3447,9 @@ func (r *spIdpConnectionResource) Schema(ctx context.Context, req resource.Schem
 										Required:            true,
 										Description:         "A list of user repository mappings from attribute names to their fulfillment values.",
 										MarkdownDescription: "A list of user repository mappings from attribute names to their fulfillment values.",
+										Validators: []validator.Map{
+											configvalidators.ValidAttributeContractFulfillment(),
+										},
 									},
 								},
 								Required:            true,

--- a/internal/resource/configvalidators/attribute_contract_fulfillment_validator.go
+++ b/internal/resource/configvalidators/attribute_contract_fulfillment_validator.go
@@ -5,6 +5,7 @@ package configvalidators
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -16,7 +17,8 @@ var _ validator.Map = &attributeContractFulfillmentValidator{}
 type attributeContractFulfillmentValidator struct{}
 
 func (v attributeContractFulfillmentValidator) Description(ctx context.Context) string {
-	return "Validates that the any `value` defined in the attribute contract fulfillment is set appropriately according to the source type."
+	return "Validates that the any `value` defined in the attribute contract fulfillment is set appropriately according to the source type, " +
+		"and that EXPRESSION-type values do not end in a trailing newline."
 }
 
 func (v attributeContractFulfillmentValidator) MarkdownDescription(ctx context.Context) string {
@@ -72,6 +74,20 @@ func (v attributeContractFulfillmentValidator) ValidateMap(ctx context.Context, 
 				providererror.InvalidAttributeConfiguration,
 				"When attribute_contract_fulfillment source type is set to anything other than 'NO_MAPPING', the value must be defined. "+
 					fmt.Sprintf("attribute_contract_fulfillment key '%s' has no value defined while using a source type of '%s'", key, sourceTypeAsString.ValueString()),
+			)
+		}
+
+		// If source type is 'EXPRESSION', the value must not end in a trailing newline. PingFederate trims
+		// trailing newlines when parsing OGNL expressions, so a value ending in "\n" (or "\r\n") in Terraform
+		// config would not match the value returned by the PingFederate admin API after apply.
+		if sourceTypeAsString.ValueString() == "EXPRESSION" && strings.HasSuffix(valueAsString.ValueString(), "\n") {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				providererror.InvalidAttributeConfiguration,
+				"When attribute_contract_fulfillment source type is set to 'EXPRESSION', the value must not end in a trailing newline. "+
+					fmt.Sprintf("attribute_contract_fulfillment key '%s' has a value ending in a trailing newline while using a source type of 'EXPRESSION'. ", key)+
+					"This commonly happens when the expression is written using Terraform heredoc syntax (e.g. `<<-EOT ... EOT`), which appends a trailing newline to the string. "+
+					"Remove the trailing newline from the value, for example by using a regular quoted string instead of a heredoc, or by wrapping the heredoc value in the `chomp()` function.",
 			)
 		}
 	}


### PR DESCRIPTION
- Add new attribute contract fulfillment validator logic to raise a validator error on expressions with trailing newlines, since the PF admin API trims them automatically
- Add new validator for expression_criteria requiring length of at least 1, since PF treats an empty expression_criteria as equivalent to null
- Add these validators across resources

Passing test pipeline: https://github.com/pingidentity/terraform-provider-pingfederate/actions/runs/34503911591