### PR TITLE
fix(oauth_token_exchange_processor_policy): verify create persisted, retry if dropped

### DIFF
--- a/.changelog/1473.txt
+++ b/.changelog/1473.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingfederate_oauth_token_exchange_processor_policy`: Fixed an issue where creation could silently fail when many token exchange processor policies were created simultaneously. The provider now verifies that a successful create actually persisted the policy, retrying with exponential backoff if not.
+```

--- a/.changelog/1473.txt
+++ b/.changelog/1473.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-`resource/pingfederate_oauth_token_exchange_processor_policy`: Fixed an issue where creation could silently fail when many token exchange processor policies were created simultaneously. The provider now verifies that a successful create actually persisted the policy, retrying with exponential backoff if not.
-```

--- a/.changelog/pr-636.txt
+++ b/.changelog/pr-636.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingfederate_oauth_token_exchange_processor_policy`: Fixed an issue where creation could silently fail when many token exchange processor policies were created concurrently. The provider now verifies that a successful create actually persisted the policy, re-issuing the create if it did not.
+```

--- a/.changelog/pr-636.txt
+++ b/.changelog/pr-636.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingfederate_oauth_token_exchange_processor_policy`: Fixed an issue where creation could silently fail when many token exchange processor policies were created concurrently. The provider now verifies that a successful create actually persisted the policy, re-issuing the create if it did not.
+`resource/pingfederate_oauth_token_exchange_processor_policy`: Fixed an issue where creation could silently fail when many policies were created concurrently. The create is now verified and re-issued if the policy was not persisted.
 ```

--- a/internal/resource/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource.go
+++ b/internal/resource/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource.go
@@ -4,11 +4,48 @@ package oauthtokenexchangeprocessorpolicies
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	client "github.com/pingidentity/pingfederate-go-client/v1300/configurationapi"
+	"github.com/pingidentity/terraform-provider-pingfederate/internal/resource/config"
 )
+
+const maxRetries = 5
+
+// Retry creates for this resource because sometimes PF silently fails to create them
+func (r *oauthTokenExchangeProcessorPolicyResource) exponentialBackOffRetryCreate(ctx context.Context, apiCreateRequest client.ApiCreateOauthTokenExchangeProcessorPolicyRequest, policyId string) (*client.TokenExchangeProcessorPolicy, *http.Response, error) {
+	var responseData *client.TokenExchangeProcessorPolicy
+	var httpResp *http.Response
+	var err error
+	backOffTime := time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		responseData, httpResp, err = r.apiClient.OauthTokenExchangeProcessorAPI.CreateOauthTokenExchangeProcessorPolicyExecute(apiCreateRequest)
+		if err != nil {
+			// If PF returned an error, don't retry
+			return responseData, httpResp, err
+		}
+
+		// If PF returned success, ensure the resource was actually created
+		_, readHttpResp, readErr := r.apiClient.OauthTokenExchangeProcessorAPI.GetOauthTokenExchangeProcessorPolicyById(config.AuthContext(ctx, r.providerConfig), policyId).Execute()
+		if readErr == nil || readHttpResp == nil || readHttpResp.StatusCode != 404 {
+			// Either the create succeeded or the read returned a non-404 status code
+			return responseData, httpResp, err
+		}
+
+		backOffTime = backOffTime * 2
+	}
+
+	tflog.Info(context.Background(), fmt.Sprintf("Request failed after %d attempts", maxRetries))
+
+	return responseData, httpResp, err
+}
 
 func (r *oauthTokenExchangeProcessorPolicyResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	var plan, state *oauthTokenExchangeProcessorPolicyResourceModel

--- a/internal/resource/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen.go
+++ b/internal/resource/config/oauth/tokenexchange/processor/policies/oauth_token_exchange_processor_policy_resource_gen.go
@@ -385,7 +385,7 @@ func (r *oauthTokenExchangeProcessorPolicyResource) Create(ctx context.Context, 
 	resp.Diagnostics.Append(diags...)
 	apiCreateRequest := r.apiClient.OauthTokenExchangeProcessorAPI.CreateOauthTokenExchangeProcessorPolicy(config.AuthContext(ctx, r.providerConfig))
 	apiCreateRequest = apiCreateRequest.Body(*clientData)
-	responseData, httpResp, err := r.apiClient.OauthTokenExchangeProcessorAPI.CreateOauthTokenExchangeProcessorPolicyExecute(apiCreateRequest)
+	responseData, httpResp, err := r.exponentialBackOffRetryCreate(ctx, apiCreateRequest, data.PolicyId.ValueString())
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while creating the oauthTokenExchangeProcessorPolicy", err, httpResp)
 		return


### PR DESCRIPTION
## Summary
- Creation of `pingfederate_oauth_token_exchange_processor_policy` can silently fail under concurrent load: the admin API returns success on the POST but the policy is never persisted. Downstream creates then fail with `Invalid access token mapping context ID` (access token mappings) or `Unrecognized Token Exchange Processor Policy ID` (OAuth clients). `time_sleep` does not help — the objects are dropped, not delayed.
- Mirrors the existing CIBA server policy request policy pattern: after a successful create POST, GET the policy by ID; a 404 means the create was silently dropped and the create is re-issued (max 5 attempts). API-reported errors return immediately without retry.
- Scope: TEPP resource only. The underlying silent-failure mode affects other endpoints too (access token mappings, OAuth clients) — that backend defect is tracked separately.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- Acceptance tests for `oauth/tokenexchange/...` pass against PF 13.0.0 container.
- Customer-style repro (100 TEPPs + ATMs + clients, `parallelism=50`, sleeps removed): unfixed provider failed 6/6 cycles with 3–17 `Invalid access token mapping context ID` errors; this branch created all 405 resources cleanly in 6/6 cycles.
- Note: `parallelism` was only the test lever to trigger the defect — the fix applies at any concurrency.

## Context
- Jira: [CDI-1473](https://pingidentity.atlassian.net/browse/CDI-1473), triaged in [TRIAGE-37102](https://pingidentity.atlassian.net/browse/TRIAGE-37102) (root cause + repro by Henry Recker).
- Retry pattern precedent: CIBA request policies (#285, commit 66fd3d38), which addressed the same silent-failure signature on `/oauth/cibaServerPolicy/requestPolicies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CDI-1473]: https://pingidentity.atlassian.net/browse/CDI-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ